### PR TITLE
Add missing translation, add qtBaseTranslator for generic window transaltions

### DIFF
--- a/i18n/XaoS_cs.ts
+++ b/i18n/XaoS_cs.ts
@@ -790,7 +790,7 @@
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="924"/>
         <location filename="../src/ui-hlp/menu.cpp" line="933"/>
-        <location filename="../src/ui/main.cpp" line="479"/>
+        <location filename="../src/ui/main.cpp" line="505"/>
         <source>Help</source>
         <translation type="unfinished">Nápověda</translation>
     </message>
@@ -883,10 +883,6 @@
         <location filename="../src/ui-hlp/menu.cpp" line="986"/>
         <source>Save image</source>
         <translation type="unfinished">Uložení obrazu</translation>
-    </message>
-    <message>
-        <source>Render animation</source>
-        <translation type="obsolete">Renderuj animaci</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="988"/>
@@ -1363,45 +1359,50 @@
         <translation type="unfinished">Novinky ve verzi 4.0</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="442"/>
+        <location filename="../src/ui/main.cpp" line="456"/>
         <source>Quit</source>
         <translation type="unfinished">Zavřít</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="445"/>
-        <location filename="../src/ui/main.cpp" line="446"/>
+        <location filename="../src/ui/main.cpp" line="459"/>
+        <location filename="../src/ui/main.cpp" line="460"/>
         <source>Message Font...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="448"/>
+        <location filename="../src/ui/main.cpp" line="462"/>
         <source>Set Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="481"/>
+        <location filename="../src/ui/main.cpp" line="465"/>
+        <source>System default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main.cpp" line="507"/>
         <source>Send Feedback</source>
         <translation type="unfinished">Zaslání zpětné vazby</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="483"/>
+        <location filename="../src/ui/main.cpp" line="509"/>
         <source>Get Updates</source>
         <translation type="unfinished">Odběr novinek</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="485"/>
+        <location filename="../src/ui/main.cpp" line="511"/>
         <source>User Forum</source>
         <translation type="unfinished">Uživatelská diskuze</translation>
     </message>
     <message>
         <location filename="../src/ui/main.cpp" line="293"/>
-        <location filename="../src/ui/main.cpp" line="488"/>
+        <location filename="../src/ui/main.cpp" line="514"/>
         <source>About</source>
         <translation type="unfinished">O XaoS</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="473"/>
-        <location filename="../src/ui/main.cpp" line="475"/>
+        <location filename="../src/ui/main.cpp" line="499"/>
+        <location filename="../src/ui/main.cpp" line="501"/>
         <source>Fullscreen</source>
         <translation type="unfinished">Celá obrazovka</translation>
     </message>
@@ -1579,37 +1580,42 @@
         <translation type="unfinished">Počet iterací:%-4i  Velikost palety barev:%i {4u?}</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2300"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2297"/>
+        <source>Bailout:%4.2f</source>
+        <translation type="unfinished">O XaoS</translation>
+    </message>
+    <message>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
         <source>Autopilot:%-4s  Plane:%s</source>
         <translation type="unfinished">Autopilot:%-4s  Plocha:%s</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2302"/>
         <source>On</source>
         <translation type="unfinished">Zapnout</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2302"/>
         <source>Off</source>
         <translation type="unfinished">Vypnout</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2305"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2306"/>
         <source>incoloring:%s    outcoloring:%s</source>
         <translation type="unfinished">vnitřní vybarvení:%s   vnější vybarvení:%s</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2310"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2311"/>
         <source>zoomspeed:%f</source>
         <translation type="unfinished">rychlost zvětšení:%f</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2314"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2315"/>
         <source>Parameter:none</source>
         <translation type="unfinished">Parametr:není</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2316"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2317"/>
         <source>Parameter:[%f,%f]</source>
         <translation type="unfinished">Parametr:[%f,%f]</translation>
     </message>

--- a/i18n/XaoS_de.ts
+++ b/i18n/XaoS_de.ts
@@ -793,7 +793,7 @@
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="924"/>
         <location filename="../src/ui-hlp/menu.cpp" line="933"/>
-        <location filename="../src/ui/main.cpp" line="479"/>
+        <location filename="../src/ui/main.cpp" line="505"/>
         <source>Help</source>
         <translation>Hilfe</translation>
     </message>
@@ -886,10 +886,6 @@
         <location filename="../src/ui-hlp/menu.cpp" line="986"/>
         <source>Save image</source>
         <translation>Bild speichern</translation>
-    </message>
-    <message>
-        <source>Render animation</source>
-        <translation type="vanished">Berechne Animation</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="988"/>
@@ -1366,45 +1362,50 @@
         <translation>Was ist neu in 4.0?</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="442"/>
+        <location filename="../src/ui/main.cpp" line="456"/>
         <source>Quit</source>
         <translation>Beenden</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="445"/>
-        <location filename="../src/ui/main.cpp" line="446"/>
+        <location filename="../src/ui/main.cpp" line="459"/>
+        <location filename="../src/ui/main.cpp" line="460"/>
         <source>Message Font...</source>
         <translation>Schriftart für Nachrichten...</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="448"/>
+        <location filename="../src/ui/main.cpp" line="462"/>
         <source>Set Language</source>
         <translation>Sprache einstellen</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="481"/>
+        <location filename="../src/ui/main.cpp" line="465"/>
+        <source>System default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main.cpp" line="507"/>
         <source>Send Feedback</source>
         <translation>Rückmeldung senden</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="483"/>
+        <location filename="../src/ui/main.cpp" line="509"/>
         <source>Get Updates</source>
         <translation>Aktuellste Version</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="485"/>
+        <location filename="../src/ui/main.cpp" line="511"/>
         <source>User Forum</source>
         <translation>Benutzerforum</translation>
     </message>
     <message>
         <location filename="../src/ui/main.cpp" line="293"/>
-        <location filename="../src/ui/main.cpp" line="488"/>
+        <location filename="../src/ui/main.cpp" line="514"/>
         <source>About</source>
         <translation>Info</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="473"/>
-        <location filename="../src/ui/main.cpp" line="475"/>
+        <location filename="../src/ui/main.cpp" line="499"/>
+        <location filename="../src/ui/main.cpp" line="501"/>
         <source>Fullscreen</source>
         <translation>Vollbildmodus</translation>
     </message>
@@ -1518,7 +1519,7 @@
     <message>
         <location filename="../src/ui-hlp/ui_helper.cpp" line="2222"/>
         <source>%s %.2f times (%.1fE) %2.2f frames/sec %c %i %i %i %u            </source>
-        <translation>%s %.2f Fach (%.1fE) %2.2f Bilder/Sek %c %i %i %i %u            </translation>
+        <translation type="unfinished">%s %.2f Fach (%.1fE) %2.2f Bilder/Sek %c %i %i %i %u            </translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/ui_helper.cpp" line="2224"/>
@@ -1583,37 +1584,42 @@
         <translation>Iterationen:%-4i Grösse der Palette:%i</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2300"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2297"/>
+        <source>Bailout:%4.2f</source>
+        <translation>Fluchtradius</translation>
+    </message>
+    <message>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
         <source>Autopilot:%-4s  Plane:%s</source>
         <translation>Autopilot:%-4s  Ebene:%s</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2302"/>
         <source>On</source>
         <translation>Ein</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2302"/>
         <source>Off</source>
         <translation>Aus</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2305"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2306"/>
         <source>incoloring:%s    outcoloring:%s</source>
         <translation>Innere Färbung:%s   Äußere Färbung:%s</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2310"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2311"/>
         <source>zoomspeed:%f</source>
         <translation>Zoomgeschwindigkeit:%f</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2314"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2315"/>
         <source>Parameter:none</source>
         <translation>Parameter:keine</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2316"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2317"/>
         <source>Parameter:[%f,%f]</source>
         <translation>Parameter:[%f,%f]</translation>
     </message>
@@ -1723,10 +1729,6 @@
         <location filename="../src/sffe/sffe.cpp" line="87"/>
         <source>Empty formula</source>
         <translation>Leere Formel</translation>
-    </message>
-    <message>
-        <source>XaoS must be restarted in order to change the number of threads.</source>
-        <translation type="vanished">XaoS muss neu gestartet werden, um die Anzahl der Threads zu ändern.</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="502"/>

--- a/i18n/XaoS_es.ts
+++ b/i18n/XaoS_es.ts
@@ -790,7 +790,7 @@
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="924"/>
         <location filename="../src/ui-hlp/menu.cpp" line="933"/>
-        <location filename="../src/ui/main.cpp" line="479"/>
+        <location filename="../src/ui/main.cpp" line="505"/>
         <source>Help</source>
         <translation type="unfinished">Ayuda</translation>
     </message>
@@ -883,10 +883,6 @@
         <location filename="../src/ui-hlp/menu.cpp" line="986"/>
         <source>Save image</source>
         <translation type="unfinished">Guardar imagen</translation>
-    </message>
-    <message>
-        <source>Render animation</source>
-        <translation type="obsolete">Renderizar animación</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="988"/>
@@ -1121,7 +1117,7 @@
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1106"/>
         <source>Bailout</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1108"/>
@@ -1363,45 +1359,50 @@
         <translation type="unfinished">¿Qué hay nuevo en 4.0?</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="442"/>
+        <location filename="../src/ui/main.cpp" line="456"/>
         <source>Quit</source>
         <translation type="unfinished">Salir</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="445"/>
-        <location filename="../src/ui/main.cpp" line="446"/>
+        <location filename="../src/ui/main.cpp" line="459"/>
+        <location filename="../src/ui/main.cpp" line="460"/>
         <source>Message Font...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="448"/>
+        <location filename="../src/ui/main.cpp" line="462"/>
         <source>Set Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="481"/>
+        <location filename="../src/ui/main.cpp" line="465"/>
+        <source>System default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main.cpp" line="507"/>
         <source>Send Feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="483"/>
+        <location filename="../src/ui/main.cpp" line="509"/>
         <source>Get Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="485"/>
+        <location filename="../src/ui/main.cpp" line="511"/>
         <source>User Forum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/ui/main.cpp" line="293"/>
-        <location filename="../src/ui/main.cpp" line="488"/>
+        <location filename="../src/ui/main.cpp" line="514"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="473"/>
-        <location filename="../src/ui/main.cpp" line="475"/>
+        <location filename="../src/ui/main.cpp" line="499"/>
+        <location filename="../src/ui/main.cpp" line="501"/>
         <source>Fullscreen</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1579,37 +1580,42 @@
         <translation type="unfinished">Iteraciones:%-4i Tamaño de la paleta:%i {4u?}</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2300"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2297"/>
+        <source>Bailout:%4.2f</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
         <source>Autopilot:%-4s  Plane:%s</source>
         <translation type="unfinished">Piloto automático:%-4s  Plano:%s</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2302"/>
         <source>On</source>
         <translation type="unfinished">On</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2302"/>
         <source>Off</source>
         <translation type="unfinished">Off</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2305"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2306"/>
         <source>incoloring:%s    outcoloring:%s</source>
         <translation type="unfinished">Color interior:%s    Color exterior:%s</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2310"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2311"/>
         <source>zoomspeed:%f</source>
         <translation type="unfinished">Velocidad zoom:%f</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2314"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2315"/>
         <source>Parameter:none</source>
         <translation type="unfinished">Parámetro:ninguno</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2316"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2317"/>
         <source>Parameter:[%f,%f]</source>
         <translation type="unfinished">Parámetro:[%f,%f]</translation>
     </message>

--- a/i18n/XaoS_fr.ts
+++ b/i18n/XaoS_fr.ts
@@ -6,138 +6,138 @@
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="105"/>
         <source>Perturbation:</source>
-        <translation type="unfinished">Perturbation :</translation>
+        <translation>Perturbation :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="109"/>
         <source>Julia-seed:</source>
-        <translation type="unfinished">Initialisation de l&apos;ensemble de Julia :</translation>
+        <translation>Initialisation de l&apos;ensemble de Julia :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="113"/>
         <source>Morphing type:</source>
-        <translation type="unfinished">Type de morphing :</translation>
+        <translation>Type de morphing :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="114"/>
         <source>Startuptime:</source>
-        <translation type="unfinished">Instant de démarrage :</translation>
+        <translation>Instant de démarrage :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="115"/>
         <source>Stoptime:</source>
-        <translation type="unfinished">Instant d&apos;arrêt :</translation>
+        <translation>Instant d&apos;arrêt :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="119"/>
         <source>File to render:</source>
-        <translation type="unfinished">Fichier à traiter :</translation>
+        <translation>Fichier à traiter :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="120"/>
         <source>Basename:</source>
-        <translation type="unfinished">Nom de base :</translation>
+        <translation>Nom de base :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="121"/>
         <source>Width:</source>
-        <translation type="unfinished">Largeur :</translation>
+        <translation>Largeur :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="122"/>
         <source>Height:</source>
-        <translation type="unfinished">Hauteur :</translation>
+        <translation>Hauteur :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="123"/>
         <source>Pixel width (cm):</source>
-        <translation type="unfinished">Largeur du pixel (cm) :</translation>
+        <translation>Largeur du pixel (cm) :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="124"/>
         <source>Pixel height (cm):</source>
-        <translation type="unfinished">Hauteur du pixel (cm) :</translation>
+        <translation>Hauteur du pixel (cm) :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="125"/>
         <source>Framerate:</source>
-        <translation type="unfinished">Taux de rafraîchissement :</translation>
+        <translation>Taux de rafraîchissement :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="126"/>
         <source>Image type:</source>
-        <translation type="unfinished">Type d&apos;image :</translation>
+        <translation>Type d&apos;image :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="127"/>
         <source>Antialiasing:</source>
-        <translation type="unfinished">Anti-crénelage :</translation>
+        <translation>Anti-crénelage :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="128"/>
         <source>Always recalculate:</source>
-        <translation type="unfinished">Toujours recalculer :</translation>
+        <translation>Toujours recalculer :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="132"/>
         <source>Center:</source>
-        <translation type="unfinished">Centre :</translation>
+        <translation>Centre :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="133"/>
         <source>Radius:</source>
-        <translation type="unfinished">Rayon :</translation>
+        <translation>Rayon :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="134"/>
         <location filename="../src/ui-hlp/menu.cpp" line="199"/>
         <source>Angle:</source>
-        <translation type="unfinished">Angle :</translation>
+        <translation>Angle :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="138"/>
         <source>Mode:</source>
-        <translation type="unfinished">Mode :</translation>
+        <translation>Mode :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="139"/>
         <source>Start:</source>
-        <translation type="unfinished">Début :</translation>
+        <translation>Début :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="140"/>
         <source>End:</source>
-        <translation type="unfinished">Fin :</translation>
+        <translation>Fin :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="144"/>
         <source>Color:</source>
-        <translation type="unfinished">Couleur :</translation>
+        <translation>Couleur :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="148"/>
         <source>Rotations per second:</source>
-        <translation type="unfinished">Rotations par seconde :</translation>
+        <translation>Rotations par seconde :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="152"/>
         <source>Letters per second:</source>
-        <translation type="unfinished">Lettres par seconde :</translation>
+        <translation>Lettres par seconde :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="156"/>
         <source>Iterations:</source>
-        <translation type="unfinished">Itérations :</translation>
+        <translation>Itérations :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="160"/>
         <source>Text:</source>
-        <translation type="unfinished">Texte :</translation>
+        <translation>Texte :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="164"/>
         <source>Your command:</source>
-        <translation type="unfinished">Votre commande :</translation>
+        <translation>Votre commande :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="168"/>
@@ -146,139 +146,139 @@
         <location filename="../src/ui-hlp/menu.cpp" line="180"/>
         <location filename="../src/ui-hlp/menu.cpp" line="236"/>
         <source>Filename:</source>
-        <translation type="unfinished">Nom de fichier :</translation>
+        <translation>Nom de fichier :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="184"/>
         <location filename="../src/ui-hlp/menu.cpp" line="276"/>
         <source>Formula:</source>
-        <translation type="unfinished">Formule :</translation>
+        <translation>Formule :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="188"/>
         <source>X center:</source>
-        <translation type="unfinished">Position horizontale centre :</translation>
+        <translation>Position horizontale centre :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="189"/>
         <source>Y center:</source>
-        <translation type="unfinished">Position verticale centre :</translation>
+        <translation>Position verticale centre :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="190"/>
         <source>X Radius:</source>
-        <translation type="unfinished">Rayon horizontal :</translation>
+        <translation>Rayon horizontal :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="191"/>
         <source>Y Radius:</source>
-        <translation type="unfinished">Rayon vertical :</translation>
+        <translation>Rayon vertical :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="195"/>
         <source>Coordinates:</source>
-        <translation type="unfinished">Coordonnées :</translation>
+        <translation>Coordonnées :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="203"/>
         <source>continuous rotation</source>
-        <translation type="unfinished">rotation continue</translation>
+        <translation>rotation continue</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="207"/>
         <source>Fast rotation</source>
-        <translation type="unfinished">Rotation rapide</translation>
+        <translation>Rotation rapide</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="211"/>
         <source>filter</source>
-        <translation type="unfinished">filtre</translation>
+        <translation>filtre</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="212"/>
         <source>enable</source>
-        <translation type="unfinished">activer</translation>
+        <translation>activer</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="216"/>
         <source>Amount:</source>
-        <translation type="unfinished">Quantité :</translation>
+        <translation>Quantité :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="220"/>
         <source>Zooming speed:</source>
-        <translation type="unfinished">Vitesse de zoom :</translation>
+        <translation>Vitesse de zoom :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="224"/>
         <source>Name:</source>
-        <translation type="unfinished">Nom :</translation>
+        <translation>Nom :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="228"/>
         <source>Bailout:</source>
-        <translation type="unfinished">Valeur d&apos;échappement :</translation>
+        <translation>Valeur d&apos;échappement :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="232"/>
         <source>Threads:</source>
-        <translation type="unfinished">Threads :</translation>
+        <translation>Threads :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="240"/>
         <source>Julia mode:</source>
-        <translation type="unfinished">Mode Julia :</translation>
+        <translation>Mode Julia :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="244"/>
         <source>Horizontal position:</source>
-        <translation type="unfinished">Position horizontale :</translation>
+        <translation>Position horizontale :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="245"/>
         <source>Vertical position:</source>
-        <translation type="unfinished">Position verticale :</translation>
+        <translation>Position verticale :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="249"/>
         <source>Dynamic resolution:</source>
-        <translation type="unfinished">Résolution dynamique :</translation>
+        <translation>Résolution dynamique :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="253"/>
         <source>Time:</source>
-        <translation type="unfinished">Heure :</translation>
+        <translation>Heure :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="257"/>
         <location filename="../src/ui-hlp/menu.cpp" line="261"/>
         <source>Number:</source>
-        <translation type="unfinished">Nombre :</translation>
+        <translation>Nombre :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="265"/>
         <source>Algorithm number:</source>
-        <translation type="unfinished">Numéro d&apos;algorithme :</translation>
+        <translation>Numéro d&apos;algorithme :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="266"/>
         <source>Seed:</source>
-        <translation type="unfinished">Valeur initiale :</translation>
+        <translation>Valeur initiale :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="267"/>
         <source>Shift:</source>
-        <translation type="unfinished">Décalage :</translation>
+        <translation>Décalage :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="271"/>
         <source>Frames per second:</source>
-        <translation type="unfinished">Images par seconde :</translation>
+        <translation>Images par seconde :</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="280"/>
         <source>Initialization:</source>
-        <translation type="unfinished">Initialisation :</translation>
+        <translation>Initialisation :</translation>
     </message>
 </context>
 <context>
@@ -286,105 +286,105 @@
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="337"/>
         <source>renderanim: Width parameter must be positive integer in the range 0..4096</source>
-        <translation type="unfinished">animation : le paramètre de largeur doit être un entier positif allant de 0 à 4096</translation>
+        <translation>animation : le paramètre de largeur doit être un entier positif allant de 0 à 4096</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="344"/>
         <source>renderanim: Height parameter must be positive integer in the range 0..4096</source>
-        <translation type="unfinished">animation : le paramètre de hauteur doit être un entier positif allant de 0 à 4096</translation>
+        <translation>animation : le paramètre de hauteur doit être un entier positif allant de 0 à 4096</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="350"/>
         <source>renderanim: Invalid real width and height dimensions</source>
-        <translation type="unfinished">animation : dimension de hauteur ou de largeur réelle incorrecte</translation>
+        <translation>animation : dimension de hauteur ou de largeur réelle incorrecte</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="355"/>
         <source>renderanim: invalid framerate</source>
-        <translation type="unfinished">animation : taux de rafraîchissement incorrect</translation>
+        <translation>animation : taux de rafraîchissement incorrect</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="360"/>
         <source>renderanim: antialiasing not supported in 256 color mode</source>
-        <translation type="unfinished">animation : anti-crénelage non supporté en mode 256 couleurs</translation>
+        <translation>animation : anti-crénelage non supporté en mode 256 couleurs</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="406"/>
         <location filename="../src/ui-hlp/menu.cpp" line="419"/>
         <source>animateview: Invalid viewpoint</source>
-        <translation type="unfinished">animation : point de vue incorrect</translation>
+        <translation>animation : point de vue incorrect</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="432"/>
         <source>Invalid viewpoint</source>
-        <translation type="unfinished">Point de vue incorrect</translation>
+        <translation>Point de vue incorrect</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="594"/>
         <source>Unknown palette type</source>
-        <translation type="unfinished">Type de palette inconnu</translation>
+        <translation>Type de palette inconnu</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="670"/>
         <location filename="../src/ui-hlp/menu.cpp" line="685"/>
         <source>Initialization of color cycling failed.</source>
-        <translation type="unfinished">Echec de l&apos;initialisation de la circulation des couleurs.</translation>
+        <translation>Echec de l&apos;initialisation de la circulation des couleurs.</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="672"/>
         <location filename="../src/ui-hlp/menu.cpp" line="687"/>
         <source>Try to enable palette emulation filter</source>
-        <translation type="unfinished">Essayez d&apos;activer le filtre d&apos;émulation de palette</translation>
+        <translation>Essayez d&apos;activer le filtre d&apos;émulation de palette</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="793"/>
         <source>Algorithm:%i seed:%i size:%i</source>
-        <translation type="unfinished">Algorithme : %i  valeur initiale : %i  taille : %i</translation>
+        <translation>Algorithme : %i  valeur initiale : %i  taille : %i</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/play.cpp" line="67"/>
         <source>line available only in animation replay</source>
-        <translation type="unfinished">ligne disponible seulement lors de répétition d&apos;animation</translation>
+        <translation>ligne disponible seulement lors de répétition d&apos;animation</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/play.cpp" line="92"/>
         <source>Morphing non existing line!</source>
-        <translation type="unfinished">Ligne de morphing non existante!</translation>
+        <translation>Ligne de morphing non existante!</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/play.cpp" line="114"/>
         <source>linekey not available in this context!</source>
-        <translation type="unfinished">ligne clé non disponible dans ce contexte!</translation>
+        <translation>ligne clé non disponible dans ce contexte!</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/play.cpp" line="279"/>
         <source>clear_line available only in animation replay</source>
-        <translation type="unfinished">effaçage de ligne disponible seulement lors de répétition d&apos;animation</translation>
+        <translation>effaçage de ligne disponible seulement lors de répétition d&apos;animation</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/play.cpp" line="288"/>
         <source>clear_lines available only in animation replay</source>
-        <translation type="unfinished">effaçage de lignes disponible seulement lors de répétition d&apos;animation</translation>
+        <translation>effaçage de lignes disponible seulement lors de répétition d&apos;animation</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/play.cpp" line="314"/>
         <source>Catalog file not found</source>
-        <translation type="unfinished">Fichier catalogue non trouvé</translation>
+        <translation>Fichier catalogue non trouvé</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/play.cpp" line="359"/>
         <source>Replay is already active</source>
-        <translation type="unfinished">Répétition déja active</translation>
+        <translation>Répétition déja active</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/play.cpp" line="363"/>
         <source>File open failed</source>
-        <translation type="unfinished">Echec d&apos;ouverture du fichier</translation>
+        <translation>Echec d&apos;ouverture du fichier</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/play.cpp" line="368"/>
         <source>Out of memory</source>
-        <translation type="unfinished">Pas assez de mémoire</translation>
+        <translation>Pas assez de mémoire</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/play.cpp" line="479"/>
@@ -392,7 +392,7 @@
         <location filename="../src/ui-hlp/play.cpp" line="518"/>
         <location filename="../src/ui-hlp/play.cpp" line="545"/>
         <source>Missing parameter</source>
-        <translation type="unfinished">Paramètre manquant</translation>
+        <translation>Paramètre manquant</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/play.cpp" line="481"/>
@@ -400,176 +400,176 @@
         <location filename="../src/ui-hlp/play.cpp" line="520"/>
         <location filename="../src/ui-hlp/play.cpp" line="547"/>
         <source>Unexpected end of file</source>
-        <translation type="unfinished">Fin inattendue de fichier</translation>
+        <translation>Fin inattendue de fichier</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/play.cpp" line="508"/>
         <location filename="../src/ui-hlp/play.cpp" line="526"/>
         <source>Token is too long</source>
-        <translation type="unfinished">Le &quot;token&quot; est trop long</translation>
+        <translation>Le &quot;token&quot; est trop long</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/play.cpp" line="579"/>
         <source>Unknown formula type</source>
-        <translation type="unfinished">Type de formule inconnu</translation>
+        <translation>Type de formule inconnu</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/play.cpp" line="585"/>
         <source>morph available only in animation replay</source>
-        <translation type="unfinished">Morphing disponible seulement lors de répétition d&apos;animation</translation>
+        <translation>Morphing disponible seulement lors de répétition d&apos;animation</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/play.cpp" line="589"/>
         <source>morphview: Invalid viewpoint</source>
-        <translation type="unfinished">Vue morphing : point de vue incorrect</translation>
+        <translation>Vue morphing : point de vue incorrect</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/play.cpp" line="603"/>
         <source>move available only in animation replay</source>
-        <translation type="unfinished">déplacement disponible seulement lors de répétition d&apos;animation</translation>
+        <translation>déplacement disponible seulement lors de répétition d&apos;animation</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/play.cpp" line="617"/>
         <source>morphjulia available only in animation replay</source>
-        <translation type="unfinished">Morphjulia disponible seulement lors de répétition d&apos;animation</translation>
+        <translation>Morphjulia disponible seulement lors de répétition d&apos;animation</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/play.cpp" line="630"/>
         <source>morphangle available only in animation replay</source>
-        <translation type="unfinished">Morphangle disponible seulement lors de répétition d&apos;animation</translation>
+        <translation>Morphangle disponible seulement lors de répétition d&apos;animation</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/play.cpp" line="665"/>
         <source>Unknown filter</source>
-        <translation type="unfinished">Filtre inconnu</translation>
+        <translation>Filtre inconnu</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/play.cpp" line="704"/>
         <source>sleep available only in animation replay</source>
-        <translation type="unfinished">pause disponible seulement lors de répétition d&apos;animation</translation>
+        <translation>pause disponible seulement lors de répétition d&apos;animation</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/play.cpp" line="719"/>
         <source>Internal program error #12 %i
 </source>
-        <translation type="unfinished">Erreur interne #12 %i
+        <translation>Erreur interne #12 %i
 </translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/play.cpp" line="738"/>
         <source>wait available only in animation replay</source>
-        <translation type="unfinished">wait disponible seulement lors de répétition d&apos;animation</translation>
+        <translation>wait disponible seulement lors de répétition d&apos;animation</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/play.cpp" line="772"/>
         <source>No catalog file loaded</source>
-        <translation type="unfinished">Pas de fichier catalogue chargé</translation>
+        <translation>Pas de fichier catalogue chargé</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/play.cpp" line="777"/>
         <source>Message not found in catalog file</source>
-        <translation type="unfinished">Message non trouvé dans fichier catalogue</translation>
+        <translation>Message non trouvé dans fichier catalogue</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/play.cpp" line="788"/>
         <source>load available only in animation replay</source>
-        <translation type="unfinished">Load disponible seulement lors de répétition d&apos;animation</translation>
+        <translation>Load disponible seulement lors de répétition d&apos;animation</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/play.cpp" line="792"/>
         <source>Include level overflow</source>
-        <translation type="unfinished">Dépassement de niveau d&apos;inclusion</translation>
+        <translation>Dépassement de niveau d&apos;inclusion</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/play.cpp" line="800"/>
         <source>File not found</source>
-        <translation type="unfinished">Fichier non trouvé</translation>
+        <translation>Fichier non trouvé</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/play.cpp" line="818"/>
         <source>Too many parameters</source>
-        <translation type="unfinished">Trop de paramètres</translation>
+        <translation>Trop de paramètres</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/render.cpp" line="35"/>
         <source>Error: %s</source>
-        <translation type="unfinished">Erreur : %s</translation>
+        <translation>Erreur : %s</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/render.cpp" line="129"/>
         <source>Cannot create palette</source>
-        <translation type="unfinished">Echec création palette</translation>
+        <translation>Echec création palette</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/render.cpp" line="143"/>
         <source>Cannot create image
 </source>
-        <translation type="unfinished">Echec création image
+        <translation>Echec création image
 </translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/render.cpp" line="151"/>
         <source>Cannot create checking buffer!</source>
-        <translation type="unfinished">Echec création tampon de vérification !</translation>
+        <translation>Echec création tampon de vérification !</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/render.cpp" line="160"/>
         <location filename="../src/ui-hlp/render.cpp" line="379"/>
         <source>Cannot create context
 </source>
-        <translation type="unfinished">Echec création contexte
+        <translation>Echec création contexte
 </translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/render.cpp" line="173"/>
         <source>Cannot open animation file
 </source>
-        <translation type="unfinished">Echec ouverture fichier d&apos;animation
+        <translation>Echec ouverture fichier d&apos;animation
 </translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/render.cpp" line="350"/>
         <location filename="../src/ui-hlp/render.cpp" line="436"/>
         <source>Calculation interrupted</source>
-        <translation type="unfinished">Calcul interrompu</translation>
+        <translation>Calcul interrompu</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/render.cpp" line="353"/>
         <location filename="../src/ui-hlp/render.cpp" line="355"/>
         <source>Calculation finished</source>
-        <translation type="unfinished">Calcul terminé</translation>
+        <translation>Calcul terminé</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/ui_helper.cpp" line="593"/>
         <source>Tutorial files not found. Reinstall XaoS</source>
-        <translation type="unfinished">Fichiers didacticiels introuvables. Réinstallez XaoS</translation>
+        <translation>Fichiers didacticiels introuvables. Réinstallez XaoS</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/ui_helper.cpp" line="608"/>
         <source>Could not open examples</source>
-        <translation type="unfinished">Echec ouverture exemples</translation>
+        <translation>Echec ouverture exemples</translation>
     </message>
     <message>
         <location filename="../src/ui/mainwindow.cpp" line="363"/>
         <source>Can not create palette</source>
-        <translation type="unfinished">Ne peut pas créer la palette</translation>
+        <translation>Ne peut pas créer la palette</translation>
     </message>
     <message>
         <location filename="../src/ui/mainwindow.cpp" line="364"/>
         <location filename="../src/ui/mainwindow.cpp" line="371"/>
         <location filename="../src/ui/mainwindow.cpp" line="399"/>
         <source>XaoS is out of memory.</source>
-        <translation type="unfinished">Pas assez de mémoire.</translation>
+        <translation>Pas assez de mémoire.</translation>
     </message>
     <message>
         <location filename="../src/ui/mainwindow.cpp" line="370"/>
         <source>Can not create image</source>
-        <translation type="unfinished">Ne peut pas créer l&apos;image</translation>
+        <translation>Ne peut pas créer l&apos;image</translation>
     </message>
     <message>
         <location filename="../src/ui/mainwindow.cpp" line="398"/>
         <source>Can not allocate tables</source>
-        <translation type="unfinished">Ne peut pas allouer les tables</translation>
+        <translation>Ne peut pas allouer les tables</translation>
     </message>
 </context>
 <context>
@@ -577,57 +577,57 @@
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="837"/>
         <source>Root menu</source>
-        <translation type="unfinished">Menu principal</translation>
+        <translation>Menu principal</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="838"/>
         <source>Animation root menu</source>
-        <translation type="unfinished">Menu principal d&apos;animation</translation>
+        <translation>Menu principal d&apos;animation</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="839"/>
         <source>Replay only commands</source>
-        <translation type="unfinished">Commandes de répétition uniquement</translation>
+        <translation>Commandes de répétition uniquement</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="842"/>
         <source>Line drawing functions</source>
-        <translation type="unfinished">Fonctions de traçage de lignes</translation>
+        <translation>Fonctions de traçage de lignes</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="843"/>
         <source>Line</source>
-        <translation type="unfinished">Ligne</translation>
+        <translation>Ligne</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="845"/>
         <source>Morph line</source>
-        <translation type="unfinished">Ligne de morphing</translation>
+        <translation>Ligne de morphing</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="847"/>
         <source>Morph last line</source>
-        <translation type="unfinished">Dernière ligne de morphing</translation>
+        <translation>Dernière ligne de morphing</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="849"/>
         <source>Set line key</source>
-        <translation type="unfinished">Choisir ligne clé</translation>
+        <translation>Choisir ligne clé</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="851"/>
         <source>Clear line</source>
-        <translation type="unfinished">Effacer ligne</translation>
+        <translation>Effacer ligne</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="853"/>
         <source>Clear all lines</source>
-        <translation type="unfinished">Effacer toutes les lignes</translation>
+        <translation>Effacer toutes les lignes</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="855"/>
         <source>Animation functions</source>
-        <translation type="unfinished">Fonctions d&apos;animation</translation>
+        <translation>Fonctions d&apos;animation</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="856"/>
@@ -636,777 +636,778 @@
         <location filename="../src/ui-hlp/menu.cpp" line="1030"/>
         <location filename="../src/ui-hlp/menu.cpp" line="1032"/>
         <source>View</source>
-        <translation type="unfinished">Vue</translation>
+        <translation>Vue</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="858"/>
         <source>Morph view</source>
-        <translation type="unfinished">Vue de morphing</translation>
+        <translation>Vue de morphing</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="860"/>
         <source>Morph julia</source>
-        <translation type="unfinished">Morphing de Julia</translation>
+        <translation>Morphing de Julia</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="862"/>
         <source>Move view</source>
-        <translation type="unfinished">Déplacer vue</translation>
+        <translation>Déplacer vue</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="864"/>
         <source>Morph angle</source>
-        <translation type="unfinished">Angle de morphing</translation>
+        <translation>Angle de morphing</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="866"/>
         <source>Zoom center</source>
-        <translation type="unfinished">Centrer le zoom</translation>
+        <translation>Centrer le zoom</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="868"/>
         <source>Zoom</source>
-        <translation type="unfinished">Zoomer</translation>
+        <translation>Zoomer</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="869"/>
         <source>Un-zoom</source>
-        <translation type="unfinished">Dézoomer</translation>
+        <translation>Dézoomer</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="871"/>
         <source>Stop zooming</source>
-        <translation type="unfinished">Arrêter de zoomer</translation>
+        <translation>Arrêter de zoomer</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="873"/>
         <source>Smooth morphing parameters</source>
-        <translation type="unfinished">Lisser les paramètres de morphing</translation>
+        <translation>Lisser les paramètres de morphing</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="875"/>
         <source>Timing functions</source>
-        <translation type="unfinished">Fonctions de temps</translation>
+        <translation>Fonctions de temps</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="876"/>
         <source>Usleep</source>
-        <translation type="unfinished">Pause</translation>
+        <translation>Pause</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="878"/>
         <source>Wait for text</source>
-        <translation type="unfinished">Attendre le texte</translation>
+        <translation>Attendre le texte</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="880"/>
         <source>Wait for complete image</source>
-        <translation type="unfinished">Attendre l&apos;image complète</translation>
+        <translation>Attendre l&apos;image complète</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="882"/>
         <source>Include file</source>
-        <translation type="unfinished">Inclure fichier</translation>
+        <translation>Inclure fichier</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="884"/>
         <location filename="../src/ui-hlp/menu.cpp" line="1057"/>
         <source>Default palette</source>
-        <translation type="unfinished">Palette par défaut</translation>
+        <translation>Palette par défaut</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="886"/>
         <source>Formula</source>
-        <translation type="unfinished">Formule</translation>
+        <translation>Formule</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="888"/>
         <source>Maximal zooming step</source>
-        <translation type="unfinished">Pas maximum pour le zoom</translation>
+        <translation>Pas maximum pour le zoom</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="890"/>
         <source>Zooming speedup</source>
-        <translation type="unfinished">Accélération du zoom</translation>
+        <translation>Accélération du zoom</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="892"/>
         <source>Filter</source>
-        <translation type="unfinished">Filtre</translation>
+        <translation>Filtre</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="896"/>
         <location filename="../src/ui-hlp/menu.cpp" line="898"/>
         <source>Letters per second</source>
-        <translation type="unfinished">Lettres par seconde</translation>
+        <translation>Lettres par seconde</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="900"/>
         <location filename="../src/ui-hlp/menu.cpp" line="1139"/>
         <source>Interrupt</source>
-        <translation type="unfinished">Interrompre</translation>
+        <translation>Interrompre</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="903"/>
         <location filename="../src/ui-hlp/menu.cpp" line="910"/>
         <source>Status</source>
-        <translation type="unfinished">Affichage état</translation>
+        <translation>Affichage état</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="906"/>
         <location filename="../src/ui-hlp/menu.cpp" line="914"/>
         <source>Ministatus</source>
-        <translation type="unfinished">Affichage mini-état</translation>
+        <translation>Affichage mini-état</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="917"/>
         <location filename="../src/ui-hlp/menu.cpp" line="926"/>
         <source>File</source>
-        <translation type="unfinished">Fichier</translation>
+        <translation>Fichier</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="918"/>
         <source>Edit</source>
-        <translation type="unfinished">Edition</translation>
+        <translation>Edition</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="919"/>
         <source>Fractal</source>
-        <translation type="unfinished">Fractale</translation>
+        <translation>Fractale</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="920"/>
         <source>Calculation</source>
-        <translation type="unfinished">Calcul</translation>
+        <translation>Calcul</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="921"/>
         <location filename="../src/ui-hlp/menu.cpp" line="1181"/>
         <source>Filters</source>
-        <translation type="unfinished">Filtres</translation>
+        <translation>Filtres</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="922"/>
         <source>Action</source>
-        <translation type="unfinished">Action</translation>
+        <translation>Action</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="924"/>
         <location filename="../src/ui-hlp/menu.cpp" line="933"/>
-        <location filename="../src/ui/main.cpp" line="479"/>
+        <location filename="../src/ui/main.cpp" line="505"/>
         <source>Help</source>
-        <translation type="unfinished">Aide</translation>
+        <translation>Aide</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="925"/>
         <source>Tutorials</source>
-        <translation type="unfinished">Didacticiels</translation>
+        <translation>Didacticiels</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="930"/>
         <source>Stop replay</source>
-        <translation type="unfinished">Arrêter la répétition</translation>
+        <translation>Arrêter la répétition</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="934"/>
         <source>Command</source>
-        <translation type="unfinished">Commande</translation>
+        <translation>Commande</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="936"/>
         <source>Play string</source>
-        <translation type="unfinished">Joue texte</translation>
+        <translation>Joue texte</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="939"/>
         <source>Clear screen</source>
-        <translation type="unfinished">Effacer l&apos;écran</translation>
+        <translation>Effacer l&apos;écran</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="941"/>
         <source>Display fractal</source>
-        <translation type="unfinished">Afficher fractale</translation>
+        <translation>Afficher fractale</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="944"/>
         <source>Display text</source>
-        <translation type="unfinished">Afficher le texte</translation>
+        <translation>Afficher le texte</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="947"/>
         <source>Text color</source>
-        <translation type="unfinished">Couleur du texte</translation>
+        <translation>Couleur du texte</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="949"/>
         <source>Horizontal text position</source>
-        <translation type="unfinished">Position horizontale du texte</translation>
+        <translation>Position horizontale du texte</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="951"/>
         <source>Vertical text position</source>
-        <translation type="unfinished">Position verticale du texte</translation>
+        <translation>Position verticale du texte</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="952"/>
         <source>Text position</source>
-        <translation type="unfinished">Position du texte</translation>
+        <translation>Position du texte</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="955"/>
         <source>Message</source>
-        <translation type="unfinished">Message</translation>
+        <translation>Message</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="973"/>
         <source>New</source>
-        <translation type="unfinished">Nouveau</translation>
+        <translation>Nouveau</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="974"/>
         <source>Open</source>
-        <translation type="unfinished">Ouvrir</translation>
+        <translation>Ouvrir</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="977"/>
         <source>Save</source>
-        <translation type="unfinished">Enregistrer</translation>
+        <translation>Enregistrer</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="980"/>
         <source>Record</source>
-        <translation type="unfinished">Enregistrer animation</translation>
+        <translation>Enregistrer animation</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="982"/>
         <source>Replay</source>
-        <translation type="unfinished">Rejouer l&apos;animation</translation>
+        <translation>Rejouer l&apos;animation</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="986"/>
         <source>Save image</source>
-        <translation type="unfinished">Enregistrer l&apos;image</translation>
-    </message>
-    <message>
-        <source>Render animation</source>
-        <translation type="obsolete">Traiter l&apos;animation</translation>
+        <translation>Enregistrer l&apos;image</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="988"/>
         <source>Render</source>
-        <translation type="unfinished">Rendre</translation>
+        <translation>Rendre</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="991"/>
         <source>Load random example</source>
-        <translation type="unfinished">Ouvrir un exemple aléatoire</translation>
+        <translation>Ouvrir un exemple aléatoire</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="993"/>
         <source>Save configuration</source>
-        <translation type="unfinished">Enregistrer la configuration</translation>
+        <translation>Enregistrer la configuration</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="996"/>
         <source>Undo</source>
-        <translation type="unfinished">Annuler</translation>
+        <translation>Annuler</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="999"/>
         <source>Redo</source>
-        <translation type="unfinished">Rétablir</translation>
+        <translation>Rétablir</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1002"/>
         <source>Formulae</source>
-        <translation type="unfinished">Formule</translation>
+        <translation>Formule</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1003"/>
         <source>More formulae</source>
-        <translation type="unfinished">Autres formules</translation>
+        <translation>Autres formules</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1008"/>
         <source>User formula</source>
-        <translation type="unfinished">Formule utilisateur</translation>
+        <translation>Formule utilisateur</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1010"/>
         <source>User initialization</source>
-        <translation type="unfinished">Initialisation utilisateur</translation>
+        <translation>Initialisation utilisateur</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1015"/>
         <source>Incoloring mode</source>
-        <translation type="unfinished">Coloriage intérieur</translation>
+        <translation>Coloriage intérieur</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1016"/>
         <source>Outcoloring mode</source>
-        <translation type="unfinished">Coloriage extérieur</translation>
+        <translation>Coloriage extérieur</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1017"/>
         <source>Plane</source>
-        <translation type="unfinished">Plan</translation>
+        <translation>Plan</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1018"/>
         <source>Palette</source>
-        <translation type="unfinished">Couleurs</translation>
+        <translation>Couleurs</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1021"/>
         <source>Mandelbrot mode</source>
-        <translation type="unfinished">Mode Mandelbrot</translation>
+        <translation>Mode Mandelbrot</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1024"/>
         <source>Julia mode</source>
-        <translation type="unfinished">Mode Julia</translation>
+        <translation>Mode Julia</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1027"/>
         <source>Fast julia mode</source>
-        <translation type="unfinished">Mode Julia rapide</translation>
+        <translation>Mode Julia rapide</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1035"/>
         <source>Rotation</source>
-        <translation type="unfinished">Rotation</translation>
+        <translation>Rotation</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1036"/>
         <source>Set angle</source>
-        <translation type="unfinished">Choisir l&apos;angle</translation>
+        <translation>Choisir l&apos;angle</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1039"/>
         <source>Set plane</source>
-        <translation type="unfinished">Choisir le plan</translation>
+        <translation>Choisir le plan</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1042"/>
         <source>Inside coloring mode</source>
-        <translation type="unfinished">Coloriage intérieur</translation>
+        <translation>Coloriage intérieur</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1045"/>
         <source>Outside coloring mode</source>
-        <translation type="unfinished">Coloriage extérieur</translation>
+        <translation>Coloriage extérieur</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1048"/>
         <source>Inside truecolor coloring mode</source>
-        <translation type="unfinished">Coloriage intérieur en vraies couleurs</translation>
+        <translation>Coloriage intérieur en vraies couleurs</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1051"/>
         <source>Outside truecolor coloring mode</source>
-        <translation type="unfinished">Coloriage extérieur en vraies couleurs</translation>
+        <translation>Coloriage extérieur en vraies couleurs</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1054"/>
         <source>Julia seed</source>
-        <translation type="unfinished">Initialisation de Julia</translation>
+        <translation>Initialisation de Julia</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1059"/>
         <source>Random palette</source>
-        <translation type="unfinished">Palette aléatoire</translation>
+        <translation>Palette aléatoire</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1061"/>
         <source>Custom palette</source>
-        <translation type="unfinished">Palette personnelle</translation>
+        <translation>Palette personnelle</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1064"/>
         <source>Color cycling</source>
-        <translation type="unfinished">Circulation des couleurs</translation>
+        <translation>Circulation des couleurs</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1066"/>
         <source>Reversed color cycling</source>
-        <translation type="unfinished">Circulation des couleurs inversée</translation>
+        <translation>Circulation des couleurs inversée</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1069"/>
         <source>Color cycling speed</source>
-        <translation type="unfinished">Vitesse de circulation des couleurs</translation>
+        <translation>Vitesse de circulation des couleurs</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1072"/>
         <source>Shift palette</source>
-        <translation type="unfinished">Décaler palette</translation>
+        <translation>Décaler palette</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1074"/>
         <source>Shift one forward</source>
-        <translation type="unfinished">Avancer d&apos;une unité</translation>
+        <translation>Avancer d&apos;une unité</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1076"/>
         <source>Shift one backward</source>
-        <translation type="unfinished">Reculer d&apos;une unité</translation>
+        <translation>Reculer d&apos;une unité</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1078"/>
         <source>Solid guessing</source>
-        <translation type="unfinished">Estimation solide</translation>
+        <translation>Estimation solide</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1079"/>
         <source>Disable solid guessing</source>
-        <translation type="unfinished">Désactiver l&apos;estimation solide</translation>
+        <translation>Désactiver l&apos;estimation solide</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1082"/>
         <source>Guess 2x2 rectangles</source>
-        <translation type="unfinished">Estimation en rectangles 2x2</translation>
+        <translation>Estimation en rectangles 2x2</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1084"/>
         <source>Guess 3x3 rectangles</source>
-        <translation type="unfinished">Estimation en rectangles 3x3</translation>
+        <translation>Estimation en rectangles 3x3</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1086"/>
         <source>Guess 4x4 rectangles</source>
-        <translation type="unfinished">Estimation en rectangles 4x4</translation>
+        <translation>Estimation en rectangles 4x4</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1088"/>
         <source>Guess 5x5 rectangles</source>
-        <translation type="unfinished">Estimation en rectangles 5x5</translation>
+        <translation>Estimation en rectangles 5x5</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1090"/>
         <source>Guess 6x6 rectangles</source>
-        <translation type="unfinished">Estimation en rectangles 6x6</translation>
+        <translation>Estimation en rectangles 6x6</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1092"/>
         <source>Guess 7x7 rectangles</source>
-        <translation type="unfinished">Estimation en rectangles 7x7</translation>
+        <translation>Estimation en rectangles 7x7</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1094"/>
         <source>Guess 8x8 rectangles</source>
-        <translation type="unfinished">Estimation en rectangles 8x8</translation>
+        <translation>Estimation en rectangles 8x8</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1096"/>
         <source>Guess unlimited rectangles</source>
-        <translation type="unfinished">Estimation en rectangles illimités</translation>
+        <translation>Estimation en rectangles illimités</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1098"/>
         <source>Dynamic resolution</source>
-        <translation type="unfinished">Résolution dynamique</translation>
+        <translation>Résolution dynamique</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1099"/>
         <source>Periodicity checking</source>
-        <translation type="unfinished">Vérification périodicité</translation>
+        <translation>Vérification périodicité</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1102"/>
         <source>Threads</source>
-        <translation type="unfinished"></translation>
+        <translation>Threads</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1104"/>
         <source>Iterations</source>
-        <translation type="unfinished">Itérations</translation>
+        <translation>Itérations</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1106"/>
         <source>Bailout</source>
-        <translation type="unfinished">Valeur d&apos;échappement</translation>
+        <translation>Valeur d&apos;échappement</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1108"/>
         <location filename="../src/ui-hlp/menu.cpp" line="1111"/>
         <location filename="../src/ui-hlp/menu.cpp" line="1185"/>
         <source>Perturbation</source>
-        <translation type="unfinished">Perturbation</translation>
+        <translation>Perturbation</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1115"/>
         <source>Zooming speed</source>
-        <translation type="unfinished">Vitesse de zoom</translation>
+        <translation>Vitesse de zoom</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1117"/>
         <source>Fixed step</source>
-        <translation type="unfinished">Pas fixé</translation>
+        <translation>Pas fixé</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1120"/>
         <source>Solid guessing range</source>
-        <translation type="unfinished">Portée de l&apos;estimation solide</translation>
+        <translation>Portée de l&apos;estimation solide</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1122"/>
         <source>Disable rotation</source>
-        <translation type="unfinished">Désactiver rotation</translation>
+        <translation>Désactiver rotation</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1125"/>
         <source>Continuous rotation</source>
-        <translation type="unfinished">Rotation continue</translation>
+        <translation>Rotation continue</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1127"/>
         <source>Rotate by mouse</source>
-        <translation type="unfinished">Rotation à la souris</translation>
+        <translation>Rotation à la souris</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1129"/>
         <source>Rotation speed</source>
-        <translation type="unfinished">Vitesse de rotation</translation>
+        <translation>Vitesse de rotation</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1131"/>
         <source>Automatic rotation</source>
-        <translation type="unfinished">Rotation automatique</translation>
+        <translation>Rotation automatique</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1133"/>
         <source>Fast rotation mode</source>
-        <translation type="unfinished">Mode de rotation rapide</translation>
+        <translation>Mode de rotation rapide</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1137"/>
         <source>Recalculate</source>
-        <translation type="unfinished">Recalculer</translation>
+        <translation>Recalculer</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1141"/>
         <source>Disable dynamic resolution</source>
-        <translation type="unfinished">Désactiver la résolution dynamique</translation>
+        <translation>Désactiver la résolution dynamique</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1144"/>
         <source>Use only during animation</source>
-        <translation type="unfinished">Utiliser seulement pendant l&apos;animation</translation>
+        <translation>Utiliser seulement pendant l&apos;animation</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1146"/>
         <source>Use also for new images</source>
-        <translation type="unfinished">Utiliser aussi pour les nouvelles images</translation>
+        <translation>Utiliser aussi pour les nouvelles images</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1148"/>
         <source>Dynamic resolution mode</source>
-        <translation type="unfinished">Mode de résolution dynamique</translation>
+        <translation>Mode de résolution dynamique</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1151"/>
         <source>Autopilot</source>
-        <translation type="unfinished">Pilote automatique</translation>
+        <translation>Pilote automatique</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1154"/>
         <source>Hide Messages</source>
-        <translation type="unfinished">Cacher les messages</translation>
+        <translation>Cacher les messages</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1157"/>
         <source>An introduction to fractals</source>
-        <translation type="unfinished">Une introduction aux fractales</translation>
+        <translation>Une introduction aux fractales</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1159"/>
         <source>XaoS features overview</source>
-        <translation type="unfinished">Aperçu des caractéristiques de XaoS</translation>
+        <translation>Aperçu des caractéristiques de XaoS</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1160"/>
         <source>Math behind fractals</source>
-        <translation type="unfinished">Les maths derrière les fractales</translation>
+        <translation>Les maths derrière les fractales</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1161"/>
         <location filename="../src/ui-hlp/menu.cpp" line="1193"/>
         <source>Other fractal types in XaoS</source>
-        <translation type="unfinished">Autres types de fractales dans XaoS</translation>
+        <translation>Autres types de fractales dans XaoS</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1163"/>
         <source>What&apos;s new?</source>
-        <translation type="unfinished">Nouveautés</translation>
+        <translation>Nouveautés</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1165"/>
         <location filename="../src/ui-hlp/menu.cpp" line="1188"/>
         <source>Whole story</source>
-        <translation type="unfinished">Tous les détails</translation>
+        <translation>Tous les détails</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1167"/>
         <source>Introduction</source>
-        <translation type="unfinished">Introduction</translation>
+        <translation>Introduction</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1168"/>
         <source>Mandelbrot set</source>
-        <translation type="unfinished">Ensemble de Mandelbrot</translation>
+        <translation>Ensemble de Mandelbrot</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1169"/>
         <source>Julia set</source>
-        <translation type="unfinished">Ensemble de Julia</translation>
+        <translation>Ensemble de Julia</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1170"/>
         <source>Higher power Mandelbrots</source>
-        <translation type="unfinished">Puissances de Mandlebrot</translation>
+        <translation>Puissances de Mandlebrot</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1171"/>
         <source>Newton&apos;s method</source>
-        <translation type="unfinished">Méthode de Newton</translation>
+        <translation>Méthode de Newton</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1172"/>
         <source>Barnsley&apos;s formula</source>
-        <translation type="unfinished">Formule de Barnsley</translation>
+        <translation>Formule de Barnsley</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1173"/>
         <source>Phoenix</source>
-        <translation type="unfinished">Phoenix</translation>
+        <translation>Phoenix</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1174"/>
         <source>Octo</source>
-        <translation type="unfinished">Octo</translation>
+        <translation>Octo</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1175"/>
         <source>Magnet</source>
-        <translation type="unfinished">Magnet</translation>
+        <translation>Magnet</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1176"/>
         <source>All features</source>
-        <translation type="unfinished">Toutes les caractéristiques</translation>
+        <translation>Toutes les caractéristiques</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1178"/>
         <source>Outcoloring modes</source>
-        <translation type="unfinished">Coloration extérieure</translation>
+        <translation>Coloration extérieure</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1179"/>
         <source>Incoloring modes</source>
-        <translation type="unfinished">Coloration intérieure</translation>
+        <translation>Coloration intérieure</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1180"/>
         <source>True-color coloring modes</source>
-        <translation type="unfinished">Coloration en vraies couleurs</translation>
+        <translation>Coloration en vraies couleurs</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1182"/>
         <source>Planes</source>
-        <translation type="unfinished">Plans</translation>
+        <translation>Plans</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1183"/>
         <source>Animations and position files</source>
-        <translation type="unfinished">Fichiers d&apos;animation et de position</translation>
+        <translation>Fichiers d&apos;animation et de position</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1186"/>
         <source>Random palettes</source>
-        <translation type="unfinished">Palettes aléatoires</translation>
+        <translation>Palettes aléatoires</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1187"/>
         <source>Other noteworthy features</source>
-        <translation type="unfinished">Autres caractéristiques utiles</translation>
+        <translation>Autres caractéristiques utiles</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1190"/>
         <source>The definition and fractal dimension</source>
-        <translation type="unfinished">Définition et dimension fractale</translation>
+        <translation>Définition et dimension fractale</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1192"/>
         <source>Escape time fractals</source>
-        <translation type="unfinished">Fractales à temps d&apos;échappement</translation>
+        <translation>Fractales à temps d&apos;échappement</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1195"/>
         <source>Triceratops and Catseye fractals</source>
-        <translation type="unfinished">Fractales Triceratops et Oeil de chat</translation>
+        <translation>Fractales Triceratops et Oeil de chat</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1197"/>
         <source>Mandelbar, Lambda, Manowar and Spider</source>
-        <translation type="unfinished">Mandelbar, Lambda, Manowar et Araignée</translation>
+        <translation>Mandelbar, Lambda, Manowar et Araignée</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1199"/>
         <source>Sierpinski Gasket, S.Carpet, Koch Snowflake</source>
-        <translation type="unfinished">Triangle de Sierpinski , Tapis de S., Flocon de Koch</translation>
+        <translation>Triangle de Sierpinski , Tapis de S., Flocon de Koch</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1201"/>
         <source>What&apos;s new in 3.0?</source>
-        <translation type="unfinished">Nouveautés dans la version 3.0</translation>
+        <translation>Nouveautés dans la version 3.0</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1202"/>
         <source>What&apos;s new in 4.0?</source>
-        <translation type="unfinished">Nouveautés dans la version 4.0</translation>
+        <translation>Nouveautés dans la version 4.0</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="442"/>
+        <location filename="../src/ui/main.cpp" line="456"/>
         <source>Quit</source>
-        <translation type="unfinished">Quitter</translation>
+        <translation>Quitter</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="445"/>
-        <location filename="../src/ui/main.cpp" line="446"/>
+        <location filename="../src/ui/main.cpp" line="459"/>
+        <location filename="../src/ui/main.cpp" line="460"/>
         <source>Message Font...</source>
-        <translation type="unfinished">Police des messages</translation>
+        <translation>Police des messages</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="448"/>
+        <location filename="../src/ui/main.cpp" line="462"/>
         <source>Set Language</source>
-        <translation type="unfinished">Choisir la langue</translation>
+        <translation>Choisir la langue</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="481"/>
+        <location filename="../src/ui/main.cpp" line="465"/>
+        <source>System default</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main.cpp" line="507"/>
         <source>Send Feedback</source>
-        <translation type="unfinished">Reporter un problème</translation>
+        <translation>Reporter un problème</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="483"/>
+        <location filename="../src/ui/main.cpp" line="509"/>
         <source>Get Updates</source>
-        <translation type="unfinished">Récuperer les mises à jour</translation>
+        <translation>Récuperer les mises à jour</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="485"/>
+        <location filename="../src/ui/main.cpp" line="511"/>
         <source>User Forum</source>
-        <translation type="unfinished">Forum des utilisateurs</translation>
+        <translation>Forum des utilisateurs</translation>
     </message>
     <message>
         <location filename="../src/ui/main.cpp" line="293"/>
-        <location filename="../src/ui/main.cpp" line="488"/>
+        <location filename="../src/ui/main.cpp" line="514"/>
         <source>About</source>
-        <translation type="unfinished">À propos</translation>
+        <translation>À propos</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="473"/>
-        <location filename="../src/ui/main.cpp" line="475"/>
+        <location filename="../src/ui/main.cpp" line="499"/>
+        <location filename="../src/ui/main.cpp" line="501"/>
         <source>Fullscreen</source>
-        <translation type="unfinished">Plein écran</translation>
+        <translation>Plein écran</translation>
     </message>
 </context>
 <context>
@@ -1415,44 +1416,44 @@
         <location filename="../src/engine/btrace.cpp" line="299"/>
         <location filename="../src/engine/btrace.cpp" line="379"/>
         <source>Boundary trace</source>
-        <translation type="unfinished">Détection de frontière</translation>
+        <translation>Détection de frontière</translation>
     </message>
     <message>
         <location filename="../src/engine/zoom.cpp" line="1012"/>
         <source>Solid guessing 1</source>
-        <translation type="unfinished">Estimation solide 1</translation>
+        <translation>Estimation solide 1</translation>
     </message>
     <message>
         <location filename="../src/engine/zoom.cpp" line="1236"/>
         <source>Solid guessing</source>
-        <translation type="unfinished">Estimation solide</translation>
+        <translation>Estimation solide</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/play.cpp" line="853"/>
         <source>Replay disabled at line %i</source>
-        <translation type="unfinished">Répétition désactivée à&#xa0;la ligne %i</translation>
+        <translation>Répétition désactivée à&#xa0;la ligne %i</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/render.cpp" line="121"/>
         <source>Initializing</source>
-        <translation type="unfinished">Initialisation</translation>
+        <translation>Initialisation</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/render.cpp" line="184"/>
         <location filename="../src/ui-hlp/render.cpp" line="388"/>
         <source>Loading catalogs</source>
-        <translation type="unfinished">Chargement catalogues</translation>
+        <translation>Chargement catalogues</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/render.cpp" line="214"/>
         <source>Processing command line options</source>
-        <translation type="unfinished">Traitement options ligne de commande</translation>
+        <translation>Traitement options ligne de commande</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/render.cpp" line="237"/>
         <source>Enabling animation replay
 </source>
-        <translation type="unfinished">Activation de la répétition d&apos;animation
+        <translation>Activation de la répétition d&apos;animation
 </translation>
     </message>
     <message>
@@ -1460,280 +1461,285 @@
         <location filename="../src/ui-hlp/render.cpp" line="246"/>
         <location filename="../src/ui-hlp/render.cpp" line="421"/>
         <source>Entering calculation loop!</source>
-        <translation type="unfinished">Entrée dans la boucle de calcul !</translation>
+        <translation>Entrée dans la boucle de calcul !</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/render.cpp" line="266"/>
         <source>Rendering frame %i...</source>
-        <translation type="unfinished">Rendu de la frame %i...</translation>
+        <translation>Rendu de la frame %i...</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/render.cpp" line="320"/>
         <source>Linking frame %i to %i...</source>
-        <translation type="unfinished"></translation>
+        <translation>Lie l&apos;image %i à l&apos;image %i...</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/render.cpp" line="438"/>
         <source>Calculation finished</source>
-        <translation type="unfinished">Calcul terminé</translation>
+        <translation>Calcul terminé</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/ui_helper.cpp" line="598"/>
         <source>Preparing first image</source>
-        <translation type="unfinished">Préparation première image</translation>
+        <translation>Préparation première image</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/ui_helper.cpp" line="615"/>
         <location filename="../src/ui-hlp/ui_helper.cpp" line="617"/>
         <source>File %s loaded.</source>
-        <translation type="unfinished">Fichier %s chargé.</translation>
+        <translation>Fichier %s chargé.</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/ui_helper.cpp" line="627"/>
         <source>Saving image...</source>
-        <translation type="unfinished">Enregistrement image...</translation>
+        <translation>Enregistrement image...</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/ui_helper.cpp" line="635"/>
         <source>Save interrupted</source>
-        <translation type="unfinished">Enregistrement interrompu</translation>
+        <translation>Enregistrement interrompu</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/ui_helper.cpp" line="644"/>
         <location filename="../src/ui-hlp/ui_helper.cpp" line="661"/>
         <location filename="../src/ui-hlp/ui_helper.cpp" line="728"/>
         <source>File %s saved.</source>
-        <translation type="unfinished">Fichier %s enregistré</translation>
+        <translation>Fichier %s enregistré</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/ui_helper.cpp" line="655"/>
         <source>Can not open file</source>
-        <translation type="unfinished">Echec ouverture fichier</translation>
+        <translation>Echec ouverture fichier</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/ui_helper.cpp" line="750"/>
         <source>Recording to file %s enabled.</source>
-        <translation type="unfinished">Enregistrement vers le fichier %s activé.</translation>
+        <translation>Enregistrement vers le fichier %s activé.</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/ui_helper.cpp" line="2222"/>
         <source>%s %.2f times (%.1fE) %2.2f frames/sec %c %i %i %i %u            </source>
-        <translation type="unfinished"></translation>
+        <translation>%s %.2f fois (%.1fE) %2.2f images/sec %c %i %i %i %u            </translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/ui_helper.cpp" line="2224"/>
         <source>unzoomed</source>
-        <translation type="unfinished">Réduit</translation>
+        <translation>Réduit</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/ui_helper.cpp" line="2224"/>
         <source>zoomed</source>
-        <translation type="unfinished">Aggrandi</translation>
+        <translation>Aggrandi</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/ui_helper.cpp" line="2230"/>
         <source>framerate:%f
 </source>
-        <translation type="unfinished">taux de rafraîchissement : %f
+        <translation>taux de rafraîchissement : %f
 </translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/ui_helper.cpp" line="2264"/>
         <source>Fractal name:%s</source>
-        <translation type="unfinished">Nom de la fractale : %s</translation>
+        <translation>Nom de la fractale : %s</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/ui_helper.cpp" line="2268"/>
         <source>Fractal type:%s</source>
-        <translation type="unfinished">Type de fractale : %s</translation>
+        <translation>Type de fractale : %s</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/ui_helper.cpp" line="2269"/>
         <source>Mandelbrot</source>
-        <translation type="unfinished">Mandelbrot</translation>
+        <translation>Mandelbrot</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/ui_helper.cpp" line="2270"/>
         <source>Julia</source>
-        <translation type="unfinished">Julia</translation>
+        <translation>Julia</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/ui_helper.cpp" line="2274"/>
         <source>Formula:%s</source>
-        <translation type="unfinished">Formule : %s</translation>
+        <translation>Formule : %s</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/ui_helper.cpp" line="2280"/>
         <source>View:[%1.12f,%1.12f]</source>
-        <translation type="unfinished">Vue : [%1.12f,%1.12f]</translation>
+        <translation>Vue : [%1.12f,%1.12f]</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/ui_helper.cpp" line="2284"/>
         <source>size:[%1.12f,%1.12f]</source>
-        <translation type="unfinished">Taille : [%1.12f,%1.12f]</translation>
+        <translation>Taille : [%1.12f,%1.12f]</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/ui_helper.cpp" line="2288"/>
         <source>Rotation:%4.2f   Screen size:%i:%i</source>
-        <translation type="unfinished">Rotation : %4.2f   Taille d&apos;écran : %i:%i</translation>
+        <translation>Rotation : %4.2f   Taille d&apos;écran : %i:%i</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/ui_helper.cpp" line="2293"/>
         <source>Iterations:%-4u Palette size:%i</source>
-        <translation type="unfinished">Itérations : %-4i Taille palette : %i {4u?}</translation>
+        <translation>Itérations : %-4i Taille palette : %i {4u?}</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2300"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2297"/>
+        <source>Bailout:%4.2f</source>
+        <translation>Valeur d&apos;échappement : %4.2f</translation>
+    </message>
+    <message>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
         <source>Autopilot:%-4s  Plane:%s</source>
-        <translation type="unfinished">Pilote automatique : %-4s  Plan : %s</translation>
+        <translation>Pilote automatique : %-4s  Plan : %s</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2302"/>
         <source>On</source>
-        <translation type="unfinished">Allumé</translation>
+        <translation>Allumé</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2302"/>
         <source>Off</source>
-        <translation type="unfinished">Éteint</translation>
+        <translation>Éteint</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2305"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2306"/>
         <source>incoloring:%s    outcoloring:%s</source>
-        <translation type="unfinished">Coloration intérieure : %s  extérieure : %s</translation>
+        <translation>Coloration intérieure : %s  extérieure : %s</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2310"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2311"/>
         <source>zoomspeed:%f</source>
-        <translation type="unfinished">Vitesse de zoom : %f</translation>
+        <translation>Vitesse de zoom : %f</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2314"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2315"/>
         <source>Parameter:none</source>
-        <translation type="unfinished">Paramètre : aucun</translation>
+        <translation>Paramètre : aucun</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2316"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2317"/>
         <source>Parameter:[%f,%f]</source>
-        <translation type="unfinished">Paramètre : [%f,%f]</translation>
+        <translation>Paramètre : [%f,%f]</translation>
     </message>
     <message>
         <location filename="../src/ui/main.cpp" line="263"/>
         <source>Thank you for using XaoS
 </source>
-        <translation type="unfinished">Merci d&apos;avoir utilisé XaoS
+        <translation>Merci d&apos;avoir utilisé XaoS
 </translation>
     </message>
     <message>
         <location filename="../src/ui/main.cpp" line="341"/>
         <source>XaoS must restart to change the language.</source>
-        <translation type="unfinished">XaoS doit redémarrer pour changer la langue.</translation>
+        <translation>XaoS doit redémarrer pour changer la langue.</translation>
     </message>
     <message>
         <location filename="../src/ui/mainwindow.cpp" line="136"/>
         <source>Enabling: %s. </source>
-        <translation type="unfinished">Activation : %s. </translation>
+        <translation>Activation : %s. </translation>
     </message>
     <message>
         <location filename="../src/ui/mainwindow.cpp" line="138"/>
         <source>Disabling: %s. </source>
-        <translation type="unfinished">Désactivation : %s. </translation>
+        <translation>Désactivation : %s. </translation>
     </message>
     <message>
         <location filename="../src/ui/mainwindow.cpp" line="171"/>
         <source>Skipping, please wait...</source>
-        <translation type="unfinished">Saute image, patientez...</translation>
+        <translation>Saute image, patientez...</translation>
     </message>
     <message>
         <location filename="../src/ui/mainwindow.cpp" line="282"/>
         <source>Letters per second %i  </source>
-        <translation type="unfinished">Lettres par seconde %i  </translation>
+        <translation>Lettres par seconde %i  </translation>
     </message>
     <message>
         <location filename="../src/ui/mainwindow.cpp" line="299"/>
         <source>Rotation speed:%2.2f degrees per second </source>
-        <translation type="unfinished">Vitesse de rotation : %2.2f degrés par seconde</translation>
+        <translation>Vitesse de rotation : %2.2f degrés par seconde</translation>
     </message>
     <message>
         <location filename="../src/ui/mainwindow.cpp" line="307"/>
         <source>Iterations: %i   </source>
-        <translation type="unfinished">Itérations: %i   </translation>
+        <translation>Itérations: %i   </translation>
     </message>
     <message>
         <location filename="../src/ui/mainwindow.cpp" line="327"/>
         <source>Cycling speed: %i   </source>
-        <translation type="unfinished">Vitesse de circulation : %i   </translation>
+        <translation>Vitesse de circulation : %i   </translation>
     </message>
     <message>
         <location filename="../src/ui/mainwindow.cpp" line="343"/>
         <source>speed:%2.2f </source>
-        <translation type="unfinished">vitesse : %2.2f</translation>
+        <translation>vitesse : %2.2f</translation>
     </message>
     <message>
         <location filename="../src/ui/mainwindow.cpp" line="524"/>
         <source>Please wait while calculating %s</source>
-        <translation type="unfinished">Patientez pendant le calcul de %s</translation>
+        <translation>Patientez pendant le calcul de %s</translation>
     </message>
     <message>
         <location filename="../src/ui/mainwindow.cpp" line="627"/>
         <source>Welcome to XaoS version %s</source>
-        <translation type="unfinished">Bienvenue sur XaoS version %s</translation>
+        <translation>Bienvenue sur XaoS version %s</translation>
     </message>
     <message>
         <location filename="../src/sffe/sffe.cpp" line="55"/>
         <source>Out of memory</source>
-        <translation type="unfinished">Pas assez de mémoire</translation>
+        <translation>Pas assez de mémoire</translation>
     </message>
     <message>
         <location filename="../src/sffe/sffe.cpp" line="58"/>
         <source>Unbalanced parentheses</source>
-        <translation type="unfinished">Parenthèses manquantes</translation>
+        <translation>Parenthèses manquantes</translation>
     </message>
     <message>
         <location filename="../src/sffe/sffe.cpp" line="62"/>
         <source>Unknown function: %s</source>
-        <translation type="unfinished">Fonction inconnue : %s</translation>
+        <translation>Fonction inconnue : %s</translation>
     </message>
     <message>
         <location filename="../src/sffe/sffe.cpp" line="66"/>
         <source>Invalid number: %s</source>
-        <translation type="unfinished">Nombre invalide : %s</translation>
+        <translation>Nombre invalide : %s</translation>
     </message>
     <message>
         <location filename="../src/sffe/sffe.cpp" line="69"/>
         <source>Unknown variable: %s</source>
-        <translation type="unfinished">Variable inconnue : %s</translation>
+        <translation>Variable inconnue : %s</translation>
     </message>
     <message>
         <location filename="../src/sffe/sffe.cpp" line="73"/>
         <source>Invalid operator: %s</source>
-        <translation type="unfinished">Opérateur invalide : %s</translation>
+        <translation>Opérateur invalide : %s</translation>
     </message>
     <message>
         <location filename="../src/sffe/sffe.cpp" line="78"/>
         <source>Internal error occurred in formula: %s</source>
-        <translation type="unfinished">Une erreur interne est survenue dans la formule : %s</translation>
+        <translation>Une erreur interne est survenue dans la formule : %s</translation>
     </message>
     <message>
         <location filename="../src/sffe/sffe.cpp" line="83"/>
         <source>Function has incorrect parameter count: %s</source>
-        <translation type="unfinished">La fonction a un nombre incorrect de paramètres : %s</translation>
+        <translation>La fonction a un nombre incorrect de paramètres : %s</translation>
     </message>
     <message>
         <location filename="../src/sffe/sffe.cpp" line="87"/>
         <source>Empty formula</source>
-        <translation type="unfinished">Formule vide</translation>
+        <translation>Formule vide</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="502"/>
         <source>XaoS must restart to change the thread count.</source>
-        <translation type="unfinished">XaoS doit redémarrer pour prendre en compte le changement de nombre de threads.</translation>
+        <translation>XaoS doit redémarrer pour prendre en compte le changement de nombre de threads.</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="503"/>
         <location filename="../src/ui/main.cpp" line="342"/>
         <source>Do you want to quit now?</source>
-        <translation type="unfinished">Voulez vous quitter maintenant ?</translation>
+        <translation>Voulez vous quitter maintenant ?</translation>
     </message>
 </context>
 </TS>

--- a/i18n/XaoS_fr.ts
+++ b/i18n/XaoS_fr.ts
@@ -1529,7 +1529,7 @@
     <message>
         <location filename="../src/ui-hlp/ui_helper.cpp" line="2224"/>
         <source>zoomed</source>
-        <translation>Aggrandi</translation>
+        <translation>Agrandi</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/ui_helper.cpp" line="2230"/>

--- a/i18n/XaoS_hi.ts
+++ b/i18n/XaoS_hi.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="hi_HI">
+<TS version="2.1" language="hi">
 <context>
     <name>Dialog</name>
     <message>
@@ -793,7 +793,7 @@
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="924"/>
         <location filename="../src/ui-hlp/menu.cpp" line="933"/>
-        <location filename="../src/ui/main.cpp" line="479"/>
+        <location filename="../src/ui/main.cpp" line="505"/>
         <source>Help</source>
         <translation type="unfinished">सहायता</translation>
     </message>
@@ -886,10 +886,6 @@
         <location filename="../src/ui-hlp/menu.cpp" line="986"/>
         <source>Save image</source>
         <translation type="unfinished">छवि सहेजें</translation>
-    </message>
-    <message>
-        <source>Render animation</source>
-        <translation type="obsolete">रेंडर एनीमेशन</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="988"/>
@@ -1124,7 +1120,7 @@
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1106"/>
         <source>Bailout</source>
-        <translation type="unfinished">सब छोड़े (Bailout)</translation>
+        <translation>सब छोड़े (Bailout)</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="1108"/>
@@ -1366,45 +1362,50 @@
         <translation type="unfinished">क्या नया है version 4.0 में</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="442"/>
+        <location filename="../src/ui/main.cpp" line="456"/>
         <source>Quit</source>
         <translation type="unfinished">प्रस्थान</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="445"/>
-        <location filename="../src/ui/main.cpp" line="446"/>
+        <location filename="../src/ui/main.cpp" line="459"/>
+        <location filename="../src/ui/main.cpp" line="460"/>
         <source>Message Font...</source>
         <translation type="unfinished">संदेश फ़ॉन्ट</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="448"/>
+        <location filename="../src/ui/main.cpp" line="462"/>
         <source>Set Language</source>
         <translation type="unfinished">Set Language (भाषा चुने)</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="481"/>
+        <location filename="../src/ui/main.cpp" line="465"/>
+        <source>System default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main.cpp" line="507"/>
         <source>Send Feedback</source>
         <translation type="unfinished">प्रतिक्रिया भेजें</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="483"/>
+        <location filename="../src/ui/main.cpp" line="509"/>
         <source>Get Updates</source>
         <translation type="unfinished">अपडेट प्राप्त करे</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="485"/>
+        <location filename="../src/ui/main.cpp" line="511"/>
         <source>User Forum</source>
         <translation type="unfinished">उपयोगकर्ता मंच</translation>
     </message>
     <message>
         <location filename="../src/ui/main.cpp" line="293"/>
-        <location filename="../src/ui/main.cpp" line="488"/>
+        <location filename="../src/ui/main.cpp" line="514"/>
         <source>About</source>
         <translation type="unfinished">बारे में</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="473"/>
-        <location filename="../src/ui/main.cpp" line="475"/>
+        <location filename="../src/ui/main.cpp" line="499"/>
+        <location filename="../src/ui/main.cpp" line="501"/>
         <source>Fullscreen</source>
         <translation type="unfinished">पूर्ण स्क्रीन</translation>
     </message>
@@ -1582,37 +1583,42 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2300"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2297"/>
+        <source>Bailout:%4.2f</source>
+        <translation type="unfinished">सब छोड़े (Bailout)</translation>
+    </message>
+    <message>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
         <source>Autopilot:%-4s  Plane:%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2302"/>
         <source>On</source>
         <translation type="unfinished">चालू</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2302"/>
         <source>Off</source>
         <translation type="unfinished">बंद</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2305"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2306"/>
         <source>incoloring:%s    outcoloring:%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2310"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2311"/>
         <source>zoomspeed:%f</source>
         <translation type="unfinished">ज़ूम गति : %f</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2314"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2315"/>
         <source>Parameter:none</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2316"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2317"/>
         <source>Parameter:[%f,%f]</source>
         <translation type="unfinished"></translation>
     </message>

--- a/i18n/XaoS_hu.ts
+++ b/i18n/XaoS_hu.ts
@@ -793,7 +793,7 @@
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="924"/>
         <location filename="../src/ui-hlp/menu.cpp" line="933"/>
-        <location filename="../src/ui/main.cpp" line="479"/>
+        <location filename="../src/ui/main.cpp" line="505"/>
         <source>Help</source>
         <translation>Segítség</translation>
     </message>
@@ -886,10 +886,6 @@
         <location filename="../src/ui-hlp/menu.cpp" line="986"/>
         <source>Save image</source>
         <translation>Kép mentése</translation>
-    </message>
-    <message>
-        <source>Render animation</source>
-        <translation type="vanished">Film készítése</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="988"/>
@@ -1366,45 +1362,50 @@
         <translation>Újdonságok a 4.0-s verzióban</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="442"/>
+        <location filename="../src/ui/main.cpp" line="456"/>
         <source>Quit</source>
         <translation>Kilépés</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="445"/>
-        <location filename="../src/ui/main.cpp" line="446"/>
+        <location filename="../src/ui/main.cpp" line="459"/>
+        <location filename="../src/ui/main.cpp" line="460"/>
         <source>Message Font...</source>
         <translation>Feliratok betűtípusa...</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="448"/>
+        <location filename="../src/ui/main.cpp" line="462"/>
         <source>Set Language</source>
         <translation>Nyelv beállítása</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="481"/>
+        <location filename="../src/ui/main.cpp" line="465"/>
+        <source>System default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main.cpp" line="507"/>
         <source>Send Feedback</source>
         <translation>Visszajelzés küldése</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="483"/>
+        <location filename="../src/ui/main.cpp" line="509"/>
         <source>Get Updates</source>
         <translation>Új verzió letöltése</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="485"/>
+        <location filename="../src/ui/main.cpp" line="511"/>
         <source>User Forum</source>
         <translation>Felhasználói fórum</translation>
     </message>
     <message>
         <location filename="../src/ui/main.cpp" line="293"/>
-        <location filename="../src/ui/main.cpp" line="488"/>
+        <location filename="../src/ui/main.cpp" line="514"/>
         <source>About</source>
         <translation>Névjegy</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="473"/>
-        <location filename="../src/ui/main.cpp" line="475"/>
+        <location filename="../src/ui/main.cpp" line="499"/>
+        <location filename="../src/ui/main.cpp" line="501"/>
         <source>Fullscreen</source>
         <translation>Teljes képernyő</translation>
     </message>
@@ -1583,37 +1584,42 @@
         <translation>Iterációk száma:%-4u Színpaletta-méret:%i</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2300"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2297"/>
+        <source>Bailout:%4.2f</source>
+        <translation type="unfinished">Szökés</translation>
+    </message>
+    <message>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
         <source>Autopilot:%-4s  Plane:%s</source>
         <translation>Robotpilóta:%-4s  Sík:%s</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2302"/>
         <source>On</source>
         <translation>Be</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2302"/>
         <source>Off</source>
         <translation>Ki</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2305"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2306"/>
         <source>incoloring:%s    outcoloring:%s</source>
         <translation>belső színezés:%s    külső színezés:%s</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2310"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2311"/>
         <source>zoomspeed:%f</source>
         <translation>belenagyítási sebesség:%f</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2314"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2315"/>
         <source>Parameter:none</source>
         <translation>Paraméter:nincs</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2316"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2317"/>
         <source>Parameter:[%f,%f]</source>
         <translation>Paraméter:[%f,%f]</translation>
     </message>
@@ -1723,14 +1729,6 @@
         <location filename="../src/sffe/sffe.cpp" line="87"/>
         <source>Empty formula</source>
         <translation>Üres képlet</translation>
-    </message>
-    <message>
-        <source>XaoS must be restarted in order to reduce the number of threads.</source>
-        <translation type="vanished">Indítsa újra a programot a tevékenységi szálak csökkentéséhez.</translation>
-    </message>
-    <message>
-        <source>XaoS must be restarted in order to change the number of threads.</source>
-        <translation type="vanished">Indítsa újra a programot a tevékenységi szálak módosításához.</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="502"/>

--- a/i18n/XaoS_is.ts
+++ b/i18n/XaoS_is.ts
@@ -284,60 +284,60 @@
 <context>
     <name>Error</name>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="330"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="337"/>
         <source>renderanim: Width parameter must be positive integer in the range 0..4096</source>
         <translation>renderanim: Breiddar-gildi verður að vera jákvæð heiltala á bilinu 0..4096</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="337"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="344"/>
         <source>renderanim: Height parameter must be positive integer in the range 0..4096</source>
         <translation>renderanim: Hæðar-gildi verður að vera jákvæð heiltala á bilinu 0..4096</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="343"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="350"/>
         <source>renderanim: Invalid real width and height dimensions</source>
         <translation>renderanim: Ógild raungildi breiddar og hæðar</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="348"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="355"/>
         <source>renderanim: invalid framerate</source>
         <translation>renderanim: ógildur fjöldi ramma á tímaeiningu</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="353"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="360"/>
         <source>renderanim: antialiasing not supported in 256 color mode</source>
         <translation>renderanim: afstöllun ekki studd í 256 lita ham</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="399"/>
-        <location filename="../src/ui-hlp/menu.cpp" line="412"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="406"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="419"/>
         <source>animateview: Invalid viewpoint</source>
         <translation>animateview: Ógildur sjónarhóll</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="425"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="432"/>
         <source>Invalid viewpoint</source>
         <translation>Ógildur sjónarhóll</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="587"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="594"/>
         <source>Unknown palette type</source>
         <translation>Óþekkt gerð litavals</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="663"/>
-        <location filename="../src/ui-hlp/menu.cpp" line="678"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="670"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="685"/>
         <source>Initialization of color cycling failed.</source>
         <translation>Frumstilling litahringjar mistókst.</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="665"/>
-        <location filename="../src/ui-hlp/menu.cpp" line="680"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="672"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="687"/>
         <source>Try to enable palette emulation filter</source>
         <translation>Reyni að leyfa hermunarsíu litavals</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="786"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="793"/>
         <source>Algorithm:%i seed:%i size:%i</source>
         <translation>Algrím:%i fræ:%i stærð:%i</translation>
     </message>
@@ -575,821 +575,837 @@
 <context>
     <name>Menu</name>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="830"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="837"/>
         <source>Root menu</source>
         <translation>Rótarvalmynd</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="831"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="838"/>
         <source>Animation root menu</source>
         <translation>Rótarvalmynd hreyfimyndar</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="832"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="839"/>
         <source>Replay only commands</source>
         <translation>Endurspila skipanir eingöngu</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="835"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="842"/>
         <source>Line drawing functions</source>
         <translation>Línuteikningarföll</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="836"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="843"/>
         <source>Line</source>
         <translation>Lína</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="838"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="845"/>
         <source>Morph line</source>
         <translation>Bræðingsmynd línu</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="840"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="847"/>
         <source>Morph last line</source>
         <translation>Bræðingsmynd síðustu línu</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="842"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="849"/>
         <source>Set line key</source>
         <translation>Skilgreina lykil línu</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="844"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="851"/>
         <source>Clear line</source>
         <translation>Eyða línu</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="846"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="853"/>
         <source>Clear all lines</source>
         <translation>Eyða öllum línum</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="848"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="855"/>
         <source>Animation functions</source>
         <translation>Aðgerðir hreyfimyndar</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="849"/>
-        <location filename="../src/ui-hlp/menu.cpp" line="916"/>
-        <location filename="../src/ui-hlp/menu.cpp" line="925"/>
-        <location filename="../src/ui-hlp/menu.cpp" line="1023"/>
-        <location filename="../src/ui-hlp/menu.cpp" line="1025"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="856"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="923"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="932"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1030"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1032"/>
         <source>View</source>
         <translation>Notandasýn</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="851"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="858"/>
         <source>Morph view</source>
         <translation>Sýn bræðingsmyndar</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="853"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="860"/>
         <source>Morph julia</source>
         <translation>Bræðingsmynd Júlíu</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="855"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="862"/>
         <source>Move view</source>
         <translation>Sýn hreyfingar</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="857"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="864"/>
         <source>Morph angle</source>
         <translation>Bræðingsmynd horns</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="859"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="866"/>
         <source>Zoom center</source>
         <translation>Þysjunarmiðja</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="861"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="868"/>
         <source>Zoom</source>
         <translation>Þysja inn</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="862"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="869"/>
         <source>Un-zoom</source>
         <translation>Þysja út</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="864"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="871"/>
         <source>Stop zooming</source>
         <translation>Stöðva þysjun</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="866"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="873"/>
         <source>Smooth morphing parameters</source>
         <translation>Samfelldir stikar bræðingsmyndar</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="868"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="875"/>
         <source>Timing functions</source>
         <translation>Tímasetningarföll</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="869"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="876"/>
         <source>Usleep</source>
         <translation>Usleep</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="871"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="878"/>
         <source>Wait for text</source>
         <translation>Bið eftir texta</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="873"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="880"/>
         <source>Wait for complete image</source>
         <translation>Bið eftir tilbúinni mynd</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="875"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="882"/>
         <source>Include file</source>
         <translation>Fella inn skrá</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="877"/>
-        <location filename="../src/ui-hlp/menu.cpp" line="1050"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="884"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1057"/>
         <source>Default palette</source>
         <translation>Sjálfgefið litaval</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="879"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="886"/>
         <source>Formula</source>
         <translation>Formúla</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="881"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="888"/>
         <source>Maximal zooming step</source>
         <translation>Stærsta þysjunarskref</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="883"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="890"/>
         <source>Zooming speedup</source>
         <translation>Þysjunarhraði</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="885"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="892"/>
         <source>Filter</source>
         <translation>Sía</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="889"/>
-        <location filename="../src/ui-hlp/menu.cpp" line="891"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="896"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="898"/>
         <source>Letters per second</source>
         <translation>Stafir á sekúndu</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="893"/>
-        <location filename="../src/ui-hlp/menu.cpp" line="1132"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="900"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1139"/>
         <source>Interrupt</source>
         <translation>Trufla</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="896"/>
         <location filename="../src/ui-hlp/menu.cpp" line="903"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="910"/>
         <source>Status</source>
         <translation>Staða</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="899"/>
-        <location filename="../src/ui-hlp/menu.cpp" line="907"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="906"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="914"/>
         <source>Ministatus</source>
         <translation>Örstaða</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="910"/>
-        <location filename="../src/ui-hlp/menu.cpp" line="919"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="917"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="926"/>
         <source>File</source>
         <translation>Skrá</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="911"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="918"/>
         <source>Edit</source>
         <translation>Breyta</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="912"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="919"/>
         <source>Fractal</source>
         <translation>Broti</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="913"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="920"/>
         <source>Calculation</source>
         <translation>Útreikningar</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="914"/>
-        <location filename="../src/ui-hlp/menu.cpp" line="1174"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="921"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1181"/>
         <source>Filters</source>
         <translation>Síur</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="915"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="922"/>
         <source>Action</source>
         <translation>Aðgerð</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="917"/>
-        <location filename="../src/ui-hlp/menu.cpp" line="926"/>
-        <location filename="../src/ui/main.cpp" line="382"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="924"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="933"/>
+        <location filename="../src/ui/main.cpp" line="505"/>
         <source>Help</source>
         <translation>Aðstoð</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="918"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="925"/>
         <source>Tutorials</source>
         <translation>Leiðbeiningar</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="923"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="930"/>
         <source>Stop replay</source>
         <translation>Stöðva endurspilun</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="927"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="934"/>
         <source>Command</source>
         <translation>Skipun</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="929"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="936"/>
         <source>Play string</source>
         <translation>Spila streng</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="932"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="939"/>
         <source>Clear screen</source>
         <translation>Hreinsa skjá</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="934"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="941"/>
         <source>Display fractal</source>
         <translation>Sýna brota</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="937"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="944"/>
         <source>Display text</source>
         <translation>Sýna texta</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="940"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="947"/>
         <source>Text color</source>
         <translation>Litur texta</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="942"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="949"/>
         <source>Horizontal text position</source>
         <translation>Lárétt staða texta</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="944"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="951"/>
         <source>Vertical text position</source>
         <translation>Lóðrétt staða texta</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="945"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="952"/>
         <source>Text position</source>
         <translation>Staða texta</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="948"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="955"/>
         <source>Message</source>
         <translation>Skilaboð</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="966"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="973"/>
         <source>New</source>
         <translation>Nýtt</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="967"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="974"/>
         <source>Open</source>
         <translation>Opna</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="970"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="977"/>
         <source>Save</source>
         <translation>Vista</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="973"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="980"/>
         <source>Record</source>
         <translation>Upptaka</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="975"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="982"/>
         <source>Replay</source>
         <translation>Endurspila</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="979"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="986"/>
         <source>Save image</source>
         <translation>Vista mynd</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="981"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="988"/>
         <source>Render</source>
         <translation>Ganga frá</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="984"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="991"/>
         <source>Load random example</source>
         <translation>Hlaða slembivöldu dæmi</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="986"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="993"/>
         <source>Save configuration</source>
         <translation>Vista stöðu</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="989"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="996"/>
         <source>Undo</source>
         <translation>Til baka</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="992"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="999"/>
         <source>Redo</source>
         <translation>Endurgera</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="995"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1002"/>
         <source>Formulae</source>
         <translation>Formúlur</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="996"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1003"/>
         <source>More formulae</source>
         <translation>Fleiri formúlur</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1001"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1008"/>
         <source>User formula</source>
         <translation>Notendaformúla</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1003"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1010"/>
         <source>User initialization</source>
         <translation>Frumstilling notanda</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1008"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1015"/>
         <source>Incoloring mode</source>
         <translation>Innlitahamur</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1009"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1016"/>
         <source>Outcoloring mode</source>
         <translation>Útlitahamur</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1010"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1017"/>
         <source>Plane</source>
         <translation>Slétta</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1011"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1018"/>
         <source>Palette</source>
         <translation>Litaval</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1014"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1021"/>
         <source>Mandelbrot mode</source>
         <translation>Mandelbrot hamur</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1017"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1024"/>
         <source>Julia mode</source>
         <translation>Júlíu hamur</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1020"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1027"/>
         <source>Fast julia mode</source>
         <translation>Hrað júlíu hamur</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1028"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1035"/>
         <source>Rotation</source>
         <translation>Snúningur</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1029"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1036"/>
         <source>Set angle</source>
         <translation>Stilla horn</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1032"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1039"/>
         <source>Set plane</source>
         <translation>Stilla sléttu</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1035"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1042"/>
         <source>Inside coloring mode</source>
         <translation>Innra litaspjald</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1038"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1045"/>
         <source>Outside coloring mode</source>
         <translation>Ytra litaspjald</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1041"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1048"/>
         <source>Inside truecolor coloring mode</source>
         <translation>Innra sannlita litaspjald</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1044"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1051"/>
         <source>Outside truecolor coloring mode</source>
         <translation>Ytra sannlita litaspjald</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1047"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1054"/>
         <source>Julia seed</source>
         <translation>Júlíu fræ</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1052"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1059"/>
         <source>Random palette</source>
         <translation>Slembival lita</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1054"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1061"/>
         <source>Custom palette</source>
         <translation>Sérval lita</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1057"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1064"/>
         <source>Color cycling</source>
         <translation>Litarás</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1059"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1066"/>
         <source>Reversed color cycling</source>
         <translation>Öfug litarás</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1062"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1069"/>
         <source>Color cycling speed</source>
         <translation>Hraði litarásar</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1065"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1072"/>
         <source>Shift palette</source>
         <translation>Hliðra litavali</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1067"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1074"/>
         <source>Shift one forward</source>
         <translation>Hliðra einn áfram</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1069"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1076"/>
         <source>Shift one backward</source>
         <translation>Hliðra einn afturábak</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1071"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1078"/>
         <source>Solid guessing</source>
         <translation>Gisk fyrir rúmskika</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1072"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1079"/>
         <source>Disable solid guessing</source>
         <translation>Afnema gisk fyrir rúmskika</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1075"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1082"/>
         <source>Guess 2x2 rectangles</source>
         <translation>Giska 2x2 ferhyrningar</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1077"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1084"/>
         <source>Guess 3x3 rectangles</source>
         <translation>Giska 3x3 ferhyrningar</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1079"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1086"/>
         <source>Guess 4x4 rectangles</source>
         <translation>Giska 4x4 ferhyrningar</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1081"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1088"/>
         <source>Guess 5x5 rectangles</source>
         <translation>Giska 5x5 ferhyrningar</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1083"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1090"/>
         <source>Guess 6x6 rectangles</source>
         <translation>Giska 6x6 ferhyrningar</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1085"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1092"/>
         <source>Guess 7x7 rectangles</source>
         <translation>Giska 7x7 ferhyrningar</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1087"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1094"/>
         <source>Guess 8x8 rectangles</source>
         <translation>Giska 8x8 ferhyrningar</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1089"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1096"/>
         <source>Guess unlimited rectangles</source>
         <translation>Giska ótakmarkaða ferhyrninga</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1091"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1098"/>
         <source>Dynamic resolution</source>
         <translation>Kvik upplausn</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1092"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1099"/>
         <source>Periodicity checking</source>
         <translation>Tímaspannsprufun</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1095"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1102"/>
         <source>Threads</source>
         <translation>Þræðir</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1097"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1104"/>
         <source>Iterations</source>
         <translation>Ítranir</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1099"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1106"/>
         <source>Bailout</source>
         <translation>Stöðvunargildi</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1101"/>
-        <location filename="../src/ui-hlp/menu.cpp" line="1104"/>
-        <location filename="../src/ui-hlp/menu.cpp" line="1178"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1108"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1111"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1185"/>
         <source>Perturbation</source>
         <translation>Truflun (perturbation)</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1108"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1115"/>
         <source>Zooming speed</source>
         <translation>Þysjunarhraði</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1110"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1117"/>
         <source>Fixed step</source>
         <translation>Föst skref</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1113"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1120"/>
         <source>Solid guessing range</source>
         <translation>Mörk giskunar rúmskika</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1115"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1122"/>
         <source>Disable rotation</source>
         <translation>Gera snúning óvirkan</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1118"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1125"/>
         <source>Continuous rotation</source>
         <translation>Samfelldur snúningur</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1120"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1127"/>
         <source>Rotate by mouse</source>
         <translation>Snúa með mús</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1122"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1129"/>
         <source>Rotation speed</source>
         <translation>Snúningshraði</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1124"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1131"/>
         <source>Automatic rotation</source>
         <translation>Sjálfvirkur snúningur</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1126"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1133"/>
         <source>Fast rotation mode</source>
         <translation>Hraður snúningshamur</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1130"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1137"/>
         <source>Recalculate</source>
         <translation>Endurreikna</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1134"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1141"/>
         <source>Disable dynamic resolution</source>
         <translation>Gera kvika upplausn óvirka</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1137"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1144"/>
         <source>Use only during animation</source>
         <translation>Nota eingöngu meðan á hreyfimynd stendur</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1139"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1146"/>
         <source>Use also for new images</source>
         <translation>Nota einnig fyrir nýjar myndir</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1141"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1148"/>
         <source>Dynamic resolution mode</source>
         <translation>Hamur kvikrar upplausnar</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1144"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1151"/>
         <source>Autopilot</source>
         <translation>Sjálfvirk stilling (autopilot)</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1147"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1154"/>
         <source>Hide Messages</source>
         <translation>Fela skilaboð</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1150"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1157"/>
         <source>An introduction to fractals</source>
         <translation>Inngangur að brotum (fractals)</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1152"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1159"/>
         <source>XaoS features overview</source>
         <translation>Yfirlit XaoS möguleika</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1153"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1160"/>
         <source>Math behind fractals</source>
         <translation>Stærðfræði að baki brotum (fractals)</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1154"/>
-        <location filename="../src/ui-hlp/menu.cpp" line="1186"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1161"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1193"/>
         <source>Other fractal types in XaoS</source>
         <translation>Aðrar gerðir brota (fractals) í XaoS</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1156"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1163"/>
         <source>What&apos;s new?</source>
         <translation>Hvað er nýtt?</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1158"/>
-        <location filename="../src/ui-hlp/menu.cpp" line="1181"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1165"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1188"/>
         <source>Whole story</source>
         <translation>Sagan öll</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1160"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1167"/>
         <source>Introduction</source>
         <translation>Inngangur</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1161"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1168"/>
         <source>Mandelbrot set</source>
         <translation>Mandelbrot mengið</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1162"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1169"/>
         <source>Julia set</source>
         <translation>Júlíu mengið</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1163"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1170"/>
         <source>Higher power Mandelbrots</source>
         <translation>Æðri velda Mandelbrot</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1164"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1171"/>
         <source>Newton&apos;s method</source>
         <translation>Aðferð Newtons</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1165"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1172"/>
         <source>Barnsley&apos;s formula</source>
         <translation>Formúla Barnsleys</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1166"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1173"/>
         <source>Phoenix</source>
         <translation>Fönix (Phoenix)</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1167"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1174"/>
         <source>Octo</source>
         <translation>Áttu (octo)</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1168"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1175"/>
         <source>Magnet</source>
         <translation>Segull</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1169"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1176"/>
         <source>All features</source>
         <translation>Öll sérkenni</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1171"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1178"/>
         <source>Outcoloring modes</source>
         <translation>Útlitar-hamar</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1172"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1179"/>
         <source>Incoloring modes</source>
         <translation>Innlitar-hamar</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1173"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1180"/>
         <source>True-color coloring modes</source>
         <translation>Sannlitar litavals hamur</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1175"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1182"/>
         <source>Planes</source>
         <translation>Sléttur</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1176"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1183"/>
         <source>Animations and position files</source>
         <translation>Hreyfimyndir og stöðu-skjöl</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1179"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1186"/>
         <source>Random palettes</source>
         <translation>Slembið litaval</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1180"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1187"/>
         <source>Other noteworthy features</source>
         <translation>Önnur mikilvæg sérkenni</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1183"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1190"/>
         <source>The definition and fractal dimension</source>
         <translation>Skilgreining og rúmvídd brota</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1185"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1192"/>
         <source>Escape time fractals</source>
         <translation>Flóttatíma brotar (escape time fractals)</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1188"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1195"/>
         <source>Triceratops and Catseye fractals</source>
         <translation>Triceratop og Kattarauga brotar</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1190"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1197"/>
         <source>Mandelbar, Lambda, Manowar and Spider</source>
         <translation>Mandelbar, Lambda, Manowar og Könguló</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1192"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1199"/>
         <source>Sierpinski Gasket, S.Carpet, Koch Snowflake</source>
         <translation>Sierpinski þríhyrningur, S.Teppi, Koch snjókornið</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="1194"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1201"/>
         <source>What&apos;s new in 3.0?</source>
         <translation>Hvað er nýtt í 3.0?</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="366"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="1202"/>
+        <source>What&apos;s new in 4.0?</source>
+        <translation type="unfinished">Hvað er nýtt í 3.0? {4.0??}</translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main.cpp" line="456"/>
         <source>Quit</source>
         <translation>Hætta</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="369"/>
-        <location filename="../src/ui/main.cpp" line="373"/>
+        <location filename="../src/ui/main.cpp" line="459"/>
+        <location filename="../src/ui/main.cpp" line="460"/>
         <source>Message Font...</source>
         <translation>Leturgerð skilaboða...</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="376"/>
-        <location filename="../src/ui/main.cpp" line="378"/>
+        <location filename="../src/ui/main.cpp" line="462"/>
+        <source>Set Language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main.cpp" line="465"/>
+        <source>System default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main.cpp" line="499"/>
+        <location filename="../src/ui/main.cpp" line="501"/>
         <source>Fullscreen</source>
         <translation>Alskjár</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="384"/>
+        <location filename="../src/ui/main.cpp" line="507"/>
         <source>Send Feedback</source>
         <translation>Senda viðbrögð</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="386"/>
+        <location filename="../src/ui/main.cpp" line="509"/>
         <source>Get Updates</source>
         <translation>Fá uppfærslu</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="388"/>
+        <location filename="../src/ui/main.cpp" line="511"/>
         <source>User Forum</source>
         <translation>Notendasvæði (forum)</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="391"/>
+        <location filename="../src/ui/main.cpp" line="293"/>
+        <location filename="../src/ui/main.cpp" line="514"/>
         <source>About</source>
         <translation>Um</translation>
     </message>
@@ -1458,12 +1474,13 @@
         <translation>Tóm formúla</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="495"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="502"/>
         <source>XaoS must restart to change the thread count.</source>
         <translation>Endurræsa þarf XaoS til að breyta talningu þráða.</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/menu.cpp" line="496"/>
+        <location filename="../src/ui-hlp/menu.cpp" line="503"/>
+        <location filename="../src/ui/main.cpp" line="342"/>
         <source>Do you want to quit now?</source>
         <translation>Viltu hætta?</translation>
     </message>
@@ -1623,37 +1640,42 @@
         <translation>Ítranir:%-4u Stærð litavals:%i</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2300"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2297"/>
+        <source>Bailout:%4.2f</source>
+        <translation type="unfinished">Stöðvunargildi</translation>
+    </message>
+    <message>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
         <source>Autopilot:%-4s  Plane:%s</source>
         <translation>Sjálfvirk stilling:%-4s  Slétta:%s</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2302"/>
         <source>On</source>
         <translation>Virkja</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2302"/>
         <source>Off</source>
         <translation>Afvirkja</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2305"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2306"/>
         <source>incoloring:%s    outcoloring:%s</source>
         <translation>innlitun:%s    útlitun:%s</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2310"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2311"/>
         <source>zoomspeed:%f</source>
         <translation>þysjunarhraði:%f</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2314"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2315"/>
         <source>Parameter:none</source>
         <translation>Stiki:enginn</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2316"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2317"/>
         <source>Parameter:[%f,%f]</source>
         <translation>Stiki:[%f,%f]</translation>
     </message>
@@ -1663,6 +1685,11 @@
 </source>
         <translation>Takk fyrir að nota XaoS
 </translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main.cpp" line="341"/>
+        <source>XaoS must restart to change the language.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/ui/mainwindow.cpp" line="136"/>
@@ -1710,7 +1737,7 @@
         <translation>Vinisamlega bíðið meðan útreikningar standa yfir %s</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="626"/>
+        <location filename="../src/ui/mainwindow.cpp" line="627"/>
         <source>Welcome to XaoS version %s</source>
         <translation>Velkomin í XaoS útg. %s</translation>
     </message>

--- a/i18n/XaoS_it.ts
+++ b/i18n/XaoS_it.ts
@@ -793,7 +793,7 @@
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="924"/>
         <location filename="../src/ui-hlp/menu.cpp" line="933"/>
-        <location filename="../src/ui/main.cpp" line="479"/>
+        <location filename="../src/ui/main.cpp" line="505"/>
         <source>Help</source>
         <translation type="unfinished">Aiuto</translation>
     </message>
@@ -886,10 +886,6 @@
         <location filename="../src/ui-hlp/menu.cpp" line="986"/>
         <source>Save image</source>
         <translation type="unfinished">Salva immagine</translation>
-    </message>
-    <message>
-        <source>Render animation</source>
-        <translation type="obsolete">Rendering animazione</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="988"/>
@@ -1366,45 +1362,50 @@
         <translation type="unfinished">Novità della versione 4.0</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="442"/>
+        <location filename="../src/ui/main.cpp" line="456"/>
         <source>Quit</source>
         <translation type="unfinished">Esci</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="445"/>
-        <location filename="../src/ui/main.cpp" line="446"/>
+        <location filename="../src/ui/main.cpp" line="459"/>
+        <location filename="../src/ui/main.cpp" line="460"/>
         <source>Message Font...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="448"/>
+        <location filename="../src/ui/main.cpp" line="462"/>
         <source>Set Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="481"/>
+        <location filename="../src/ui/main.cpp" line="465"/>
+        <source>System default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main.cpp" line="507"/>
         <source>Send Feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="483"/>
+        <location filename="../src/ui/main.cpp" line="509"/>
         <source>Get Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="485"/>
+        <location filename="../src/ui/main.cpp" line="511"/>
         <source>User Forum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/ui/main.cpp" line="293"/>
-        <location filename="../src/ui/main.cpp" line="488"/>
+        <location filename="../src/ui/main.cpp" line="514"/>
         <source>About</source>
         <translation type="unfinished">Informazioni su...</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="473"/>
-        <location filename="../src/ui/main.cpp" line="475"/>
+        <location filename="../src/ui/main.cpp" line="499"/>
+        <location filename="../src/ui/main.cpp" line="501"/>
         <source>Fullscreen</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1583,37 +1584,42 @@
         <translation type="unfinished">Iterazioni:%-4i Dimensione tavolozza:%i {4u?}</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2300"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2297"/>
+        <source>Bailout:%4.2f</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
         <source>Autopilot:%-4s  Plane:%s</source>
         <translation type="unfinished">Pilota automatico:%-4s Piano:%s</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2302"/>
         <source>On</source>
         <translation type="unfinished">Attivo</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2302"/>
         <source>Off</source>
         <translation type="unfinished">Disattivo</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2305"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2306"/>
         <source>incoloring:%s    outcoloring:%s</source>
         <translation type="unfinished">colorazione interna:%s colorazione esterna:%s</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2310"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2311"/>
         <source>zoomspeed:%f</source>
         <translation type="unfinished">velocità di ingrandimento:%f</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2314"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2315"/>
         <source>Parameter:none</source>
         <translation type="unfinished">Parametro:nessuno</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2316"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2317"/>
         <source>Parameter:[%f,%f]</source>
         <translation type="unfinished">Parametro:[%f,%f]</translation>
     </message>

--- a/i18n/XaoS_pt.ts
+++ b/i18n/XaoS_pt.ts
@@ -793,7 +793,7 @@
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="924"/>
         <location filename="../src/ui-hlp/menu.cpp" line="933"/>
-        <location filename="../src/ui/main.cpp" line="479"/>
+        <location filename="../src/ui/main.cpp" line="505"/>
         <source>Help</source>
         <translation type="unfinished">Ajuda</translation>
     </message>
@@ -886,10 +886,6 @@
         <location filename="../src/ui-hlp/menu.cpp" line="986"/>
         <source>Save image</source>
         <translation type="unfinished">Salvar a imagem</translation>
-    </message>
-    <message>
-        <source>Render animation</source>
-        <translation type="obsolete">Processar animação</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="988"/>
@@ -1366,45 +1362,50 @@
         <translation type="unfinished">Quais são as novidades da versão 4.0?</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="442"/>
+        <location filename="../src/ui/main.cpp" line="456"/>
         <source>Quit</source>
         <translation type="unfinished">Sair</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="445"/>
-        <location filename="../src/ui/main.cpp" line="446"/>
+        <location filename="../src/ui/main.cpp" line="459"/>
+        <location filename="../src/ui/main.cpp" line="460"/>
         <source>Message Font...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="448"/>
+        <location filename="../src/ui/main.cpp" line="462"/>
         <source>Set Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="481"/>
+        <location filename="../src/ui/main.cpp" line="465"/>
+        <source>System default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main.cpp" line="507"/>
         <source>Send Feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="483"/>
+        <location filename="../src/ui/main.cpp" line="509"/>
         <source>Get Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="485"/>
+        <location filename="../src/ui/main.cpp" line="511"/>
         <source>User Forum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/ui/main.cpp" line="293"/>
-        <location filename="../src/ui/main.cpp" line="488"/>
+        <location filename="../src/ui/main.cpp" line="514"/>
         <source>About</source>
         <translation type="unfinished">Sobre</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="473"/>
-        <location filename="../src/ui/main.cpp" line="475"/>
+        <location filename="../src/ui/main.cpp" line="499"/>
+        <location filename="../src/ui/main.cpp" line="501"/>
         <source>Fullscreen</source>
         <translation type="unfinished">Tela cheia</translation>
     </message>
@@ -1582,37 +1583,42 @@
         <translation type="unfinished">Iteracões:%-4i Tamanho da paleta:%i {4u?}</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2300"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2297"/>
+        <source>Bailout:%4.2f</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
         <source>Autopilot:%-4s  Plane:%s</source>
         <translation type="unfinished">Piloto automático:%-4s  Plano:%s</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2302"/>
         <source>On</source>
         <translation type="unfinished">Ligado</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2302"/>
         <source>Off</source>
         <translation type="unfinished">Desligado</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2305"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2306"/>
         <source>incoloring:%s    outcoloring:%s</source>
         <translation type="unfinished">Cor interna:%s    Cor externa:%s</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2310"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2311"/>
         <source>zoomspeed:%f</source>
         <translation type="unfinished">Velocidade da ampliação:%f</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2314"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2315"/>
         <source>Parameter:none</source>
         <translation type="unfinished">Parâmetro:nenhum</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2316"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2317"/>
         <source>Parameter:[%f,%f]</source>
         <translation type="unfinished">Parâmetro:[%f,%f]</translation>
     </message>

--- a/i18n/XaoS_ro.ts
+++ b/i18n/XaoS_ro.ts
@@ -793,7 +793,7 @@
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="924"/>
         <location filename="../src/ui-hlp/menu.cpp" line="933"/>
-        <location filename="../src/ui/main.cpp" line="479"/>
+        <location filename="../src/ui/main.cpp" line="505"/>
         <source>Help</source>
         <translation type="unfinished">Ajutor</translation>
     </message>
@@ -886,10 +886,6 @@
         <location filename="../src/ui-hlp/menu.cpp" line="986"/>
         <source>Save image</source>
         <translation type="unfinished">Salveaza imaginea</translation>
-    </message>
-    <message>
-        <source>Render animation</source>
-        <translation type="obsolete">Proceseaza animatia</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="988"/>
@@ -1366,45 +1362,50 @@
         <translation type="unfinished">Ce este nou in versiunea 4.0?</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="442"/>
+        <location filename="../src/ui/main.cpp" line="456"/>
         <source>Quit</source>
         <translation type="unfinished">Terminare</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="445"/>
-        <location filename="../src/ui/main.cpp" line="446"/>
+        <location filename="../src/ui/main.cpp" line="459"/>
+        <location filename="../src/ui/main.cpp" line="460"/>
         <source>Message Font...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="448"/>
+        <location filename="../src/ui/main.cpp" line="462"/>
         <source>Set Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="481"/>
+        <location filename="../src/ui/main.cpp" line="465"/>
+        <source>System default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main.cpp" line="507"/>
         <source>Send Feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="483"/>
+        <location filename="../src/ui/main.cpp" line="509"/>
         <source>Get Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="485"/>
+        <location filename="../src/ui/main.cpp" line="511"/>
         <source>User Forum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/ui/main.cpp" line="293"/>
-        <location filename="../src/ui/main.cpp" line="488"/>
+        <location filename="../src/ui/main.cpp" line="514"/>
         <source>About</source>
         <translation type="unfinished">Despre</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="473"/>
-        <location filename="../src/ui/main.cpp" line="475"/>
+        <location filename="../src/ui/main.cpp" line="499"/>
+        <location filename="../src/ui/main.cpp" line="501"/>
         <source>Fullscreen</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1583,37 +1584,42 @@
         <translation type="unfinished">Iteratii:%-4i  Dimensiunea paletei:%i {4u?}</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2300"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2297"/>
+        <source>Bailout:%4.2f</source>
+        <translation type="unfinished">Valoare de salvare (bailout)</translation>
+    </message>
+    <message>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
         <source>Autopilot:%-4s  Plane:%s</source>
         <translation type="unfinished">Pilot automat:%-4s    Plan:%s</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2302"/>
         <source>On</source>
         <translation type="unfinished">Pornit</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2302"/>
         <source>Off</source>
         <translation type="unfinished">Oprit</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2305"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2306"/>
         <source>incoloring:%s    outcoloring:%s</source>
         <translation type="unfinished">Culoare interioara:%s  Culoare exterioara:%s</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2310"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2311"/>
         <source>zoomspeed:%f</source>
         <translation type="unfinished">viteza de marire (zoomspeed):%f</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2314"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2315"/>
         <source>Parameter:none</source>
         <translation type="unfinished">Parametri:nici unul</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2316"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2317"/>
         <source>Parameter:[%f,%f]</source>
         <translation type="unfinished">Parametri:[%f,%f]</translation>
     </message>

--- a/i18n/XaoS_rs.ts
+++ b/i18n/XaoS_rs.ts
@@ -793,7 +793,7 @@
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="924"/>
         <location filename="../src/ui-hlp/menu.cpp" line="933"/>
-        <location filename="../src/ui/main.cpp" line="479"/>
+        <location filename="../src/ui/main.cpp" line="505"/>
         <source>Help</source>
         <translation>Pomoć</translation>
     </message>
@@ -1362,45 +1362,50 @@
         <translation>Šta je novo u 4.0?</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="442"/>
+        <location filename="../src/ui/main.cpp" line="456"/>
         <source>Quit</source>
         <translation>Odustani</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="445"/>
-        <location filename="../src/ui/main.cpp" line="446"/>
+        <location filename="../src/ui/main.cpp" line="459"/>
+        <location filename="../src/ui/main.cpp" line="460"/>
         <source>Message Font...</source>
         <translation>Font poruke...</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="448"/>
+        <location filename="../src/ui/main.cpp" line="462"/>
         <source>Set Language</source>
         <translation>Podesi jezik</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="473"/>
-        <location filename="../src/ui/main.cpp" line="475"/>
+        <location filename="../src/ui/main.cpp" line="465"/>
+        <source>System default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main.cpp" line="499"/>
+        <location filename="../src/ui/main.cpp" line="501"/>
         <source>Fullscreen</source>
         <translation>Ceo ekran</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="481"/>
+        <location filename="../src/ui/main.cpp" line="507"/>
         <source>Send Feedback</source>
         <translation>Pošalji povratnu informaciju</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="483"/>
+        <location filename="../src/ui/main.cpp" line="509"/>
         <source>Get Updates</source>
         <translation>Ažuriranje</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="485"/>
+        <location filename="../src/ui/main.cpp" line="511"/>
         <source>User Forum</source>
         <translation>Forum korisnika</translation>
     </message>
     <message>
         <location filename="../src/ui/main.cpp" line="293"/>
-        <location filename="../src/ui/main.cpp" line="488"/>
+        <location filename="../src/ui/main.cpp" line="514"/>
         <source>About</source>
         <translation>O</translation>
     </message>
@@ -1635,37 +1640,42 @@
         <translation>Iteracija:%-4u Veličina palete:%i</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2300"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2297"/>
+        <source>Bailout:%4.2f</source>
+        <translation type="unfinished">Spašavanje</translation>
+    </message>
+    <message>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
         <source>Autopilot:%-4s  Plane:%s</source>
         <translation>Autopilot:%-4s  Ravan:%s</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2302"/>
         <source>On</source>
         <translation>Uključeno</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2302"/>
         <source>Off</source>
         <translation>Isključeno</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2305"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2306"/>
         <source>incoloring:%s    outcoloring:%s</source>
         <translation>unutrašnja boja:%s    spoljašnja boja:%s</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2310"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2311"/>
         <source>zoomspeed:%f</source>
         <translation>brzina povećanja</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2314"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2315"/>
         <source>Parameter:none</source>
         <translation>Parametar:nema</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2316"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2317"/>
         <source>Parameter:[%f,%f]</source>
         <translation>Parametar:[%f,%f]</translation>
     </message>

--- a/i18n/XaoS_ru.ts
+++ b/i18n/XaoS_ru.ts
@@ -793,7 +793,7 @@
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="924"/>
         <location filename="../src/ui-hlp/menu.cpp" line="933"/>
-        <location filename="../src/ui/main.cpp" line="479"/>
+        <location filename="../src/ui/main.cpp" line="505"/>
         <source>Help</source>
         <translation type="unfinished">Справка</translation>
     </message>
@@ -886,10 +886,6 @@
         <location filename="../src/ui-hlp/menu.cpp" line="986"/>
         <source>Save image</source>
         <translation type="unfinished">Сохранить изображение</translation>
-    </message>
-    <message>
-        <source>Render animation</source>
-        <translation type="obsolete">Анимация рендеринга</translation>
     </message>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="988"/>
@@ -1366,45 +1362,50 @@
         <translation type="unfinished">Что нового в 4.0?</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="442"/>
+        <location filename="../src/ui/main.cpp" line="456"/>
         <source>Quit</source>
         <translation type="unfinished">Выход</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="445"/>
-        <location filename="../src/ui/main.cpp" line="446"/>
+        <location filename="../src/ui/main.cpp" line="459"/>
+        <location filename="../src/ui/main.cpp" line="460"/>
         <source>Message Font...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="448"/>
+        <location filename="../src/ui/main.cpp" line="462"/>
         <source>Set Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="481"/>
+        <location filename="../src/ui/main.cpp" line="465"/>
+        <source>System default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main.cpp" line="507"/>
         <source>Send Feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="483"/>
+        <location filename="../src/ui/main.cpp" line="509"/>
         <source>Get Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="485"/>
+        <location filename="../src/ui/main.cpp" line="511"/>
         <source>User Forum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/ui/main.cpp" line="293"/>
-        <location filename="../src/ui/main.cpp" line="488"/>
+        <location filename="../src/ui/main.cpp" line="514"/>
         <source>About</source>
         <translation type="unfinished">О программе</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="473"/>
-        <location filename="../src/ui/main.cpp" line="475"/>
+        <location filename="../src/ui/main.cpp" line="499"/>
+        <location filename="../src/ui/main.cpp" line="501"/>
         <source>Fullscreen</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1583,37 +1584,42 @@
         <translation type="unfinished">Итерации:%-4i Размер палитры:%i {4u?}</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2300"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2297"/>
+        <source>Bailout:%4.2f</source>
+        <translation type="unfinished">Спасение</translation>
+    </message>
+    <message>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
         <source>Autopilot:%-4s  Plane:%s</source>
         <translation type="unfinished">Автопилот:%-4s  Плоскость:%s</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2302"/>
         <source>On</source>
         <translation type="unfinished">Вкл</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2302"/>
         <source>Off</source>
         <translation type="unfinished">Выкл</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2305"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2306"/>
         <source>incoloring:%s    outcoloring:%s</source>
         <translation type="unfinished">окрашивание внутри:%s    окрашивание снаружи:%s</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2310"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2311"/>
         <source>zoomspeed:%f</source>
         <translation type="unfinished">скорость масштабирования:%f</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2314"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2315"/>
         <source>Parameter:none</source>
         <translation type="unfinished">Параметр:пусто</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2316"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2317"/>
         <source>Parameter:[%f,%f]</source>
         <translation type="unfinished">Параметр:[%f,%f]</translation>
     </message>

--- a/i18n/XaoS_sk.ts
+++ b/i18n/XaoS_sk.ts
@@ -789,7 +789,7 @@
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="924"/>
         <location filename="../src/ui-hlp/menu.cpp" line="933"/>
-        <location filename="../src/ui/main.cpp" line="479"/>
+        <location filename="../src/ui/main.cpp" line="505"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1358,45 +1358,50 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="442"/>
+        <location filename="../src/ui/main.cpp" line="456"/>
         <source>Quit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="445"/>
-        <location filename="../src/ui/main.cpp" line="446"/>
+        <location filename="../src/ui/main.cpp" line="459"/>
+        <location filename="../src/ui/main.cpp" line="460"/>
         <source>Message Font...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="448"/>
+        <location filename="../src/ui/main.cpp" line="462"/>
         <source>Set Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="473"/>
-        <location filename="../src/ui/main.cpp" line="475"/>
+        <location filename="../src/ui/main.cpp" line="465"/>
+        <source>System default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main.cpp" line="499"/>
+        <location filename="../src/ui/main.cpp" line="501"/>
         <source>Fullscreen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="481"/>
+        <location filename="../src/ui/main.cpp" line="507"/>
         <source>Send Feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="483"/>
+        <location filename="../src/ui/main.cpp" line="509"/>
         <source>Get Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="485"/>
+        <location filename="../src/ui/main.cpp" line="511"/>
         <source>User Forum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/ui/main.cpp" line="293"/>
-        <location filename="../src/ui/main.cpp" line="488"/>
+        <location filename="../src/ui/main.cpp" line="514"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1629,37 +1634,42 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2300"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2297"/>
+        <source>Bailout:%4.2f</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
         <source>Autopilot:%-4s  Plane:%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2302"/>
         <source>On</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2302"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2305"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2306"/>
         <source>incoloring:%s    outcoloring:%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2310"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2311"/>
         <source>zoomspeed:%f</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2314"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2315"/>
         <source>Parameter:none</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2316"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2317"/>
         <source>Parameter:[%f,%f]</source>
         <translation type="unfinished"></translation>
     </message>

--- a/i18n/XaoS_sv.ts
+++ b/i18n/XaoS_sv.ts
@@ -795,7 +795,7 @@ Sluttid:</translation>
     <message>
         <location filename="../src/ui-hlp/menu.cpp" line="924"/>
         <location filename="../src/ui-hlp/menu.cpp" line="933"/>
-        <location filename="../src/ui/main.cpp" line="479"/>
+        <location filename="../src/ui/main.cpp" line="505"/>
         <source>Help</source>
         <translation>Hjälp</translation>
     </message>
@@ -1364,45 +1364,50 @@ Sluttid:</translation>
         <translation>Vad är nytt i version 4.0?</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="442"/>
+        <location filename="../src/ui/main.cpp" line="456"/>
         <source>Quit</source>
         <translation>Avsluta</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="445"/>
-        <location filename="../src/ui/main.cpp" line="446"/>
+        <location filename="../src/ui/main.cpp" line="459"/>
+        <location filename="../src/ui/main.cpp" line="460"/>
         <source>Message Font...</source>
         <translation>Typsnitt för meddelanden...</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="448"/>
+        <location filename="../src/ui/main.cpp" line="462"/>
         <source>Set Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="473"/>
-        <location filename="../src/ui/main.cpp" line="475"/>
+        <location filename="../src/ui/main.cpp" line="465"/>
+        <source>System default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main.cpp" line="499"/>
+        <location filename="../src/ui/main.cpp" line="501"/>
         <source>Fullscreen</source>
         <translation>Helskärmsläge</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="481"/>
+        <location filename="../src/ui/main.cpp" line="507"/>
         <source>Send Feedback</source>
         <translation>Skicka feedback</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="483"/>
+        <location filename="../src/ui/main.cpp" line="509"/>
         <source>Get Updates</source>
         <translation>Leta efter uppdateringar</translation>
     </message>
     <message>
-        <location filename="../src/ui/main.cpp" line="485"/>
+        <location filename="../src/ui/main.cpp" line="511"/>
         <source>User Forum</source>
         <translation>Användarforum</translation>
     </message>
     <message>
         <location filename="../src/ui/main.cpp" line="293"/>
-        <location filename="../src/ui/main.cpp" line="488"/>
+        <location filename="../src/ui/main.cpp" line="514"/>
         <source>About</source>
         <translation>Om</translation>
     </message>
@@ -1639,37 +1644,42 @@ Mandelbrot</translation>
         <translation>Itereringar:%-4u Palette storlekar:%i</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2300"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2297"/>
+        <source>Bailout:%4.2f</source>
+        <translation type="unfinished">Maxgräns (bailout)</translation>
+    </message>
+    <message>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
         <source>Autopilot:%-4s  Plane:%s</source>
         <translation>Autopilot:%-4s  Plan:%s</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2302"/>
         <source>On</source>
         <translation>På</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2301"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2302"/>
         <source>Off</source>
         <translation>Av</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2305"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2306"/>
         <source>incoloring:%s    outcoloring:%s</source>
         <translation>infärgning: %s    utfärgning: %s</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2310"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2311"/>
         <source>zoomspeed:%f</source>
         <translation>zoomhastighet: %f</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2314"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2315"/>
         <source>Parameter:none</source>
         <translation>Parameter: ingen</translation>
     </message>
     <message>
-        <location filename="../src/ui-hlp/ui_helper.cpp" line="2316"/>
+        <location filename="../src/ui-hlp/ui_helper.cpp" line="2317"/>
         <source>Parameter:[%f,%f]</source>
         <translation>Parameter: [%f, %f]</translation>
     </message>

--- a/src/ui-hlp/ui_helper.cpp
+++ b/src/ui-hlp/ui_helper.cpp
@@ -2294,7 +2294,8 @@ static void uih_drawstatus(uih_context *uih, void * /*data*/)
             uih->fcontext->maxiter, uih->image->palette->size);
     xprint(uih->image, uih->font, 0, statusstart + 5 * h, str, FGCOLOR(uih),
            BGCOLOR(uih), 0);
-    sprintf(str, "Bailout:%4.2f", (double)uih->fcontext->bailout);
+    sprintf(str, TR("Message", "Bailout:%4.2f"),
+            (double)uih->fcontext->bailout);
     xprint(uih->image, uih->font, 0, statusstart + 6 * h, str, FGCOLOR(uih),
            BGCOLOR(uih), 0);
     sprintf(str, TR("Message", "Autopilot:%-4s  Plane:%s"),

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -385,6 +385,7 @@ static void ui_unregistermenus(void)
 }
 
 QTranslator qtTranslator;
+QTranslator qtBaseTranslator;
 QTranslator xaosTranslator;
 char languageSetting[6] = "";
 bool languageSysDefault = true;
@@ -432,7 +433,11 @@ void setLanguage(const char *lang) {
     qtTranslator.load("qt_" + language,
                       QLibraryInfo::location(QLibraryInfo::TranslationsPath));
     qApp->installTranslator(&qtTranslator);
-    xaosTranslator.load("XaoS_" + language, ":/i18n");
+    qtBaseTranslator.load(QLocale::system(),
+                          QStringLiteral("qtbase_"));
+    qApp->installTranslator(&qtBaseTranslator);
+    xaosTranslator.load("XaoS_" + language,
+                        ":/i18n");
     qApp->installTranslator(&xaosTranslator);
 
     /* Without this some locales (e.g. the Hungarian) replaces "." to ","


### PR DESCRIPTION
- Add missing translation in Status (bailout was forgotten). I added the TR function in the code and added translation in all .ts files when "bailout" was translated in other contexts
- Add QtBase Translator => allow to translate buttons liks Apply / Cancel / Ok / Open in system windows (like save / open windows)
- some spelling in french translation