### PR TITLE
Include cstdlib for calloc/free

### DIFF
--- a/src/util/timers.cpp
+++ b/src/util/timers.cpp
@@ -23,6 +23,7 @@
  */
 #include "config.h"
 #include "timers.h"
+#include <cstdlib>
 #include <climits>
 #include <chrono>
 #include <thread>


### PR DESCRIPTION
Fixes build failure with GCC 10, which had some header dependency
changes:  https://gcc.gnu.org/gcc-10/porting_to.html