### PR TITLE
Fix crashes on blank recording

### DIFF
--- a/src/util/xstdio.cpp
+++ b/src/util/xstdio.cpp
@@ -111,9 +111,9 @@ xio_path xio_getdirectory(xio_constpath filename)
 
 xio_path xio_getfilename(const char *basename, const char *extension)
 {
-    int pathlength = sizeof(basename) + sizeof(extension);
+    int pathlength = strlen(basename) + strlen(extension);
     static char* name;
-    name = (char* )malloc(pathlength * sizeof (char));
+    name = (char* )malloc(pathlength);
     int nimage = 0;
     struct stat sb;
     char *base = xio_fixpath(basename);


### PR DESCRIPTION
After #156 the crashes remained on using record function when starting from blank, this PR fixes them.