### PR TITLE
Invalid Commands only produce error message

### DIFF
--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -102,11 +102,12 @@ int ui_params_parser(int argc, char **argv)
     int is;
     const struct params *par = NULL;
     int error = 0;
+    int show_help = 0;
     int found;
     for (i = 1; i < argc && !error; i++) {
         found = 0;
         if (!strcmp("-help", argv[i])) {
-            error = 1;
+            show_help = 1;
             break;
         }
         for (d = 0; d < nparams; d++) {
@@ -182,6 +183,9 @@ int ui_params_parser(int argc, char **argv)
             i = ie;
     }
     if (error) {
+        return 0;
+    }
+    if (show_help) {
         const char *name[] = {"", "number", "string", "f.point"};
         printf("                 XaoS" XaoS_VERSION " help text\n\n");
         printf("option string   param   description\n\n");

--- a/src/util/xmenu.cpp
+++ b/src/util/xmenu.cpp
@@ -720,7 +720,7 @@ int menu_processargs(int n, int argc, char **argv)
     margv = argv;
     error = menu_processcommand(NULL, gettoken, 0, MENUFLAG_NOOPTION, "root");
     if (error) {
-        x_error("%s", error);
+        x_error("%s\nPlease enter `xaos -help` to learn more on command line options", error);
         return -1;
     }
     return (argpos - 2);


### PR DESCRIPTION
The last implementation shown help message along with error message on every unavailable commands.

Now the errors message is produced as:
```
> xaos -unavailable function
> unavailable function:unknown function
Please enter `xaos -help` to learn more on command line options
```

PS: This is part 1 of #155 
