### PR TITLE
Save xpf data in png chunk

### DIFF
--- a/src/include/misc-f.h
+++ b/src/include/misc-f.h
@@ -5,6 +5,7 @@
 struct image;
 
 const char *writepng(xio_constpath filename, const struct image *image);
+const char *readpng(xio_constpath filename);
 void XaoS_srandom(unsigned int x);
 long int XaoS_random(void);
 char *mystrdup(const char *);

--- a/src/include/ui_helper.h
+++ b/src/include/ui_helper.h
@@ -456,6 +456,7 @@ void uih_playtutorial(struct uih_context *c, const char *name);
 void uih_loadfile(struct uih_context *uih, xio_constpath d);
 void uih_playfile(struct uih_context *c, xio_constpath d);
 void uih_loadexample(struct uih_context *c);
+void uih_loadpngfile(struct uih_context *c, xio_constpath d);
 void uih_savepngfile(struct uih_context *c, xio_constpath d);
 void uih_saveposfile(struct uih_context *c, xio_constpath d);
 char *uih_savepostostr(struct uih_context *c);

--- a/src/ui-hlp/menu.cpp
+++ b/src/ui-hlp/menu.cpp
@@ -62,7 +62,7 @@ const char *const uih_colornames[] = {"white", "black", "red", NULL};
  * Zoltan Kovacs <kovzol@math.u-szeged.hu>, 2003-01-05
  */
 
-#define MAX_MENUDIALOGS_I18N 100
+#define MAX_MENUDIALOGS_I18N 102
 #define Register(variable) variable = &menudialogs_i18n[no_menudialogs_i18n]
 static menudialog menudialogs_i18n[MAX_MENUDIALOGS_I18N];
 // static int no_menudialogs_i18n;
@@ -76,7 +76,7 @@ static menudialog *uih_perturbationdialog, *uih_juliadialog,
     *uih_filterdialog, *uih_shiftdialog, *uih_speeddialog, *printdialog,
     *uih_bailoutdialog, *uih_threaddialog, *saveanimdialog, *uih_juliamodedialog,
     *uih_textposdialog, *uih_fastmodedialog, *uih_timedialog, *uih_numdialog,
-    *uih_fpdialog, *palettedialog, *uih_cyclingdialog
+    *uih_fpdialog, *palettedialog, *uih_cyclingdialog, *loadimgdialog
 #ifdef USE_SFFE
     ,
     *uih_sffedialog, *uih_sffeinitdialog
@@ -170,6 +170,10 @@ void uih_registermenudialogs_i18n(void)
 
     Register(playdialog);
     DIALOGIFILE_I(TR("Dialog", "Filename:"), "anim*.xaf");
+    NULL_I();
+
+    Register(loadimgdialog);
+    DIALOGIFILE_I(TR("Dialog", "Filename:"), "fract*.png");
     NULL_I();
 
     Register(saveimgdialog);
@@ -983,6 +987,8 @@ void uih_registermenus_i18n(void)
                  MENUFLAG_INTERRUPT | MENUFLAG_NOPLAY, uih_playfile,
                  playdialog);
     MENUSEPARATOR_I("file");
+    MENUDIALOG_I("file", NULL, TR("Menu", "Open image"), "loadimg",
+                MENUFLAG_INTERRUPT, uih_loadpngfile, loadimgdialog);
     MENUDIALOG_I("file", NULL, TR("Menu", "Save image"), "saveimg", 0,
                  uih_savepngfile, saveimgdialog);
     MENUDIALOG_I("file", NULL, TR("Menu", "Render"), "renderanim", UI,

--- a/src/ui-hlp/ui_helper.cpp
+++ b/src/ui-hlp/ui_helper.cpp
@@ -633,7 +633,7 @@ void uih_loadpngfile(struct uih_context *c, xio_constpath d)
         uih_error(c, TR("Error", "Could not open Image"));
         return;
     }
-    uih_loadfile(c, "xaos_temp.xpf");
+    uih_loadfile(c, ".xaos_temp.xpf");
     if(c->errstring == NULL) {
         char s[256];
         sprintf(s, TR("Message", "File %s loaded."), d);
@@ -658,7 +658,7 @@ void uih_savepngfile(struct uih_context *c, xio_constpath d)
         return;
     }
     c->errstring = NULL;
-    uih_saveposfile(c, "xaos_temp.xpf");
+    uih_saveposfile(c, ".xaos_temp.xpf");
     s = uih_save(c, d);
     if (s != NULL)
         uih_error(c, s);

--- a/src/ui-hlp/ui_helper.cpp
+++ b/src/ui-hlp/ui_helper.cpp
@@ -620,6 +620,28 @@ void uih_loadexample(struct uih_context *c)
     }
 }
 
+void uih_loadpngfile(struct uih_context *c, xio_constpath d)
+{
+    xio_file f;
+    f = xio_ropen(d);
+    if (f == NULL) {
+        uih_error(c, strerror(errno));
+        return;
+    }
+    const char *s = readpng(d);
+    if(s != NULL) {
+        uih_error(c, TR("Error", "Could not open Image"));
+        return;
+    }
+    uih_loadfile(c, "xaos_temp.xpf");
+    if(c->errstring == NULL) {
+        char s[256];
+        sprintf(s, TR("Message", "File %s loaded."), d);
+        uih_message(c, s);
+    }
+    return;
+}
+
 void uih_savepngfile(struct uih_context *c, xio_constpath d)
 {
     const char *s;
@@ -636,6 +658,7 @@ void uih_savepngfile(struct uih_context *c, xio_constpath d)
         return;
     }
     c->errstring = NULL;
+    uih_saveposfile(c, "xaos_temp.xpf");
     s = uih_save(c, d);
     if (s != NULL)
         uih_error(c, s);

--- a/src/ui/image_qt.cpp
+++ b/src/ui/image_qt.cpp
@@ -61,10 +61,40 @@ int xtextcharw(struct image */*image*/, void *font, const char c)
     return metrics.width(c);
 }
 
+// Saves image as png with xpf chunk data
 const char *writepng(xio_constpath filename, const struct image *image)
 {
     QImage *qimage = reinterpret_cast<QImage **>(image->data)[image->currimage];
+    QFile f("xaos_temp.xpf");
+    if(!f.open(QFile::ReadOnly |
+                  QFile::Text))
+    {
+        qDebug()<<"Could not open the file for reading";
+    }
+    QTextStream in(&f);
+    QString xpf_chunk = in.readAll();
+    f.close();
+    f.remove();
+    qimage->setText("Metadata", xpf_chunk);
     qimage->save(filename);
+    return NULL;
+}
+
+// Reads png image and xpf associated data
+const char *readpng(xio_constpath filename)
+{
+    QImageReader reader(filename);
+    const QImage xaos_image = reader.read();
+    QString xpf_chunk = xaos_image.text("Metadata");
+    QFile f("xaos_temp.xpf");
+    if(!f.open(QFile::WriteOnly |
+                  QFile::Text))
+    {
+        qDebug() << " Could not open the file for writing";
+    }
+    QTextStream in(&f);
+    in<<xpf_chunk;
+    f.close();
     return NULL;
 }
 

--- a/src/ui/image_qt.cpp
+++ b/src/ui/image_qt.cpp
@@ -65,7 +65,7 @@ int xtextcharw(struct image */*image*/, void *font, const char c)
 const char *writepng(xio_constpath filename, const struct image *image)
 {
     QImage *qimage = reinterpret_cast<QImage **>(image->data)[image->currimage];
-    QFile f("xaos_temp.xpf");
+    QFile f(".xaos_temp.xpf");
     if(!f.open(QFile::ReadOnly |
                   QFile::Text))
     {
@@ -86,7 +86,7 @@ const char *readpng(xio_constpath filename)
     QImageReader reader(filename);
     const QImage xaos_image = reader.read();
     QString xpf_chunk = xaos_image.text("Metadata");
-    QFile f("xaos_temp.xpf");
+    QFile f(".xaos_temp.xpf");
     if(!f.open(QFile::WriteOnly |
                   QFile::Text))
     {


### PR DESCRIPTION
Type : Enhancement
Fixes #128 

Changes:
Added option to 'Open Image' under File menu.T
This option allows to save & open PNG without XPF data.