### PR TITLE
Remove grid text

### DIFF
--- a/src/ui-hlp/ui_helper.cpp
+++ b/src/ui-hlp/ui_helper.cpp
@@ -2230,7 +2230,6 @@ static int statusstart;
 static struct uih_window *statuswindow = NULL;
 static int ministatusstart;
 static struct uih_window *ministatuswindow = NULL;
-int cartesiangridstart;
 static struct uih_window *cartesiangridwindow = NULL;
 
 void uih_updatestatus(uih_context *uih)
@@ -2267,9 +2266,6 @@ void uih_updatestarts(uih_context *uih)
     ministatusstart = y;
     if (ministatuswindow != NULL)
         y += xtextheight(uih->image, uih->font);
-    cartesiangridstart = y;
-    if (cartesiangridwindow != NULL)
-        y += xtextheight(uih->image, uih->font) * 2;
     statusstart = y;
     if (statuswindow != NULL)
         y += xtextheight(uih->image, uih->font) * STATUSLINES;
@@ -2423,20 +2419,6 @@ static void uih_cartesiangridpos(uih_context *uih, int *x, int *y, int *w, int *
 
 static void uih_drawcartesiangrid(uih_context *uih, void * /*data*/)
 {
-    char statustext[256];
-    int h = xtextheight(uih->image, uih->font);
-    long double rr = uih->fcontext->s.rr/10.0;
-    long double counter=0;
-    while(rr < 1){
-        rr *= 10;
-        counter++;
-    }
-    sprintf(statustext, "X-axis: 1 grid = %f", pow(10.0, -counter+1));
-    xprint(uih->image, uih->font, 0, cartesiangridstart, statustext, FGCOLOR(uih),
-           BGCOLOR(uih), 0);
-    sprintf(statustext, "Y-axis: 1 grid = %f", pow(10.0, -counter+1));
-    xprint(uih->image, uih->font, 0, cartesiangridstart + h, statustext, FGCOLOR(uih),
-           BGCOLOR(uih), 0);
     overlayGrid(uih, FGCOLOR(uih));
 }
 


### PR DESCRIPTION
Removes grid text from Cartesian grid display
The same status can be obtained through ```Size``` parameter in ```Status```