### PR TITLE
Fix saving image on Mac in 4.1pre1 

### DIFF
--- a/src/ui-hlp/ui_helper.cpp
+++ b/src/ui-hlp/ui_helper.cpp
@@ -633,7 +633,9 @@ void uih_loadpngfile(struct uih_context *c, xio_constpath d)
         uih_error(c, TR("Error", "Could not open image"));
         return;
     }
-    char filepath[4096];
+    int pathlength = strlen(d) + 16;
+    static char* filepath;
+    filepath = (char* )malloc(pathlength * sizeof (char));
     strcpy(filepath, xio_getdirectory(d));
     strcat(filepath, ".xaos_temp.xpf");
     uih_loadfile(c, filepath);
@@ -661,7 +663,9 @@ void uih_savepngfile(struct uih_context *c, xio_constpath d)
         return;
     }
     c->errstring = NULL;
-    char filepath[4096];
+    int pathlength = strlen(d) + 16;
+    static char* filepath;
+    filepath = (char* )malloc(pathlength * sizeof (char));
     strcpy(filepath, xio_getdirectory(d));
     strcat(filepath, ".xaos_temp.xpf");
     uih_saveposfile(c, filepath);

--- a/src/ui/image_qt.cpp
+++ b/src/ui/image_qt.cpp
@@ -70,8 +70,6 @@ const char *writepng(xio_constpath filename, const struct image *image)
     filepath = (char* )malloc(pathlength * sizeof (char));
     strcpy(filepath, xio_getdirectory(filename));
     strcat(filepath, ".xaos_temp.xpf");
-    printf("%s\n", filepath);
-    fflush(stdout);
     QFile f(filepath);
     if(!f.open(QFile::ReadOnly |
                   QFile::Text))

--- a/src/ui/image_qt.cpp
+++ b/src/ui/image_qt.cpp
@@ -65,9 +65,13 @@ int xtextcharw(struct image */*image*/, void *font, const char c)
 const char *writepng(xio_constpath filename, const struct image *image)
 {
     QImage *qimage = reinterpret_cast<QImage **>(image->data)[image->currimage];
-    char filepath[4096];
+    int pathlength = strlen(filename) + 16;
+    static char* filepath;
+    filepath = (char* )malloc(pathlength * sizeof (char));
     strcpy(filepath, xio_getdirectory(filename));
     strcat(filepath, ".xaos_temp.xpf");
+    printf("%s\n", filepath);
+    fflush(stdout);
     QFile f(filepath);
     if(!f.open(QFile::ReadOnly |
                   QFile::Text))
@@ -93,7 +97,9 @@ const char *readpng(xio_constpath filename)
     if(xpf_chunk.isNull() || xpf_chunk.isEmpty()) {
         return "Not valid image";
     }
-    char filepath[4096];
+    int pathlength = strlen(filename) + 16;
+    static char* filepath;
+    filepath = (char* )malloc(pathlength * sizeof (char));
     strcpy(filepath, xio_getdirectory(filename));
     strcat(filepath, ".xaos_temp.xpf");
     QFile f(filepath);


### PR DESCRIPTION
After #176, saving images on mac failed sometimes due to memory leak issues in Mac.
This PR resolves it.
Fixes #174 