### PR TITLE
Do not use temporary an XPF file when saving/loading from a PNG

### DIFF
--- a/src/include/misc-f.h
+++ b/src/include/misc-f.h
@@ -4,8 +4,8 @@
 #include "config.h"
 struct image;
 
-const char *writepng(xio_constpath filename, const struct image *image);
-const char *readpng(xio_constpath filename);
+const char *writepng(xio_constpath filename, const struct image *image, xio_file xpf_data);
+const char* readpng(xio_constpath filename);
 void XaoS_srandom(unsigned int x);
 long int XaoS_random(void);
 char *mystrdup(const char *);

--- a/src/include/ui_helper.h
+++ b/src/include/ui_helper.h
@@ -387,7 +387,7 @@ void uih_autopilot_off(uih_context *c);
 
 /*misc functions */
 int uih_update(uih_context *c, int mousex, int mousey, int mousebuttons);
-const char *uih_save(struct uih_context *c, xio_constpath filename);
+const char *uih_save(struct uih_context *c, xio_constpath filename, xio_file xpf_data);
 void uih_tbreak(uih_context *c);
 double uih_displayed(uih_context *c);
 void uih_do_fractal(uih_context *c);

--- a/src/ui-hlp/render.cpp
+++ b/src/ui-hlp/render.cpp
@@ -301,7 +301,7 @@ int uih_renderanimation(struct uih_context *gc1, const char *basename,
                 curframe.angle = uih->fcontext->angle;
                 curframe.name = s;
                 curframe.newimage = newimage;
-                writepng(s, uih->image);
+                writepng(s, uih->image, NULL);
                 uih_displayed(uih);
                 lastframenum = framenum;
             } else {

--- a/src/ui-hlp/ui_helper.cpp
+++ b/src/ui-hlp/ui_helper.cpp
@@ -628,17 +628,13 @@ void uih_loadpngfile(struct uih_context *c, xio_constpath d)
         uih_error(c, strerror(errno));
         return;
     }
-    const char *s = readpng(d);
-    if(s != NULL) {
+    const char* xpf_chunk = readpng(d);
+    if(xpf_chunk == NULL) {
         uih_error(c, TR("Error", "Could not open image"));
         return;
     }
-    int pathlength = strlen(d) + 16;
-    static char* filepath;
-    filepath = (char* )malloc(pathlength * sizeof (char));
-    strcpy(filepath, xio_getdirectory(d));
-    strcat(filepath, ".xaos_temp.xpf");
-    uih_loadfile(c, filepath);
+    xio_file xpf_data = xio_strropen(xpf_chunk);
+    uih_load(c, xpf_data, d);
     if(c->errstring == NULL) {
         char s[256];
         sprintf(s, TR("Message", "File %s loaded."), d);
@@ -663,13 +659,9 @@ void uih_savepngfile(struct uih_context *c, xio_constpath d)
         return;
     }
     c->errstring = NULL;
-    int pathlength = strlen(d) + 16;
-    static char* filepath;
-    filepath = (char* )malloc(pathlength * sizeof (char));
-    strcpy(filepath, xio_getdirectory(d));
-    strcat(filepath, ".xaos_temp.xpf");
-    uih_saveposfile(c, filepath);
-    s = uih_save(c, d);
+    xio_file xpf_data = xio_strwopen();
+    uih_save_position(c, xpf_data, UIH_SAVEPOS);
+    s = uih_save(c, d, xpf_data);
     if (s != NULL)
         uih_error(c, s);
     if (c->errstring == NULL) {
@@ -786,13 +778,13 @@ void uih_saveanimfile(struct uih_context *c, xio_constpath d)
     uih_updatemenus(c, "record");
 }
 
-const char *uih_save(struct uih_context *c, xio_constpath filename)
+const char *uih_save(struct uih_context *c, xio_constpath filename, xio_file xpf_data)
 {
     const char *r;
     uih_cycling_stop(c);
     uih_stoptimers(c);
     uih_clearwindows(c);
-    r = writepng(filename, c->queue->saveimage);
+    r = writepng(filename, c->queue->saveimage, xpf_data);
     uih_cycling_continue(c);
     uih_resumetimers(c);
     return (r);


### PR DESCRIPTION
Fixes #179 
Potential Fix for #174 (to be checked)

This removes dependency over temporary file used in ver 4.1 for saving images with xaos and reading them back.