### PR TITLE
Revert "Support for Batch Rendering"

### DIFF
--- a/src/include/xmenu.h
+++ b/src/include/xmenu.h
@@ -32,7 +32,6 @@ typedef char *(*tokenfunc)(struct uih_context *c);
 #define DIALOG_ONOFF 8
 #define DIALOG_COORD 9
 #define DIALOG_PALSLIDER 10
-#define DIALOG_IFILES 11
 
 #define DIALOGIFILE(question, filename)                                        \
     {                                                                          \
@@ -73,10 +72,6 @@ typedef char *(*tokenfunc)(struct uih_context *c);
 #define DIALOGPALSLIDER(question, default)                                     \
     {                                                                          \
         question, DIALOG_SLIDER, default                                       \
-    }
-#define DIALOGIFILES(question, filenames)                                      \
-    {                                                                          \
-        question, DIALOG_IFILES, 0, filenames                                  \
     }
 
 #define DIALOGIFILE_I(_question, _filename)                                    \
@@ -149,15 +144,6 @@ typedef char *(*tokenfunc)(struct uih_context *c);
     menudialogs_i18n[no_menudialogs_i18n].question = _question;                \
     menudialogs_i18n[no_menudialogs_i18n].type = DIALOG_PALSLIDER;             \
     menudialogs_i18n[no_menudialogs_i18n].defint = _default;                   \
-    ++no_menudialogs_i18n;
-
-#define DIALOGIFILES_I(_question, _filenames)                                  \
-    menudialogs_i18n[no_menudialogs_i18n].question = _question;                \
-    menudialogs_i18n[no_menudialogs_i18n].type = DIALOG_IFILES;                \
-    menudialogs_i18n[no_menudialogs_i18n].defint = 0;                          \
-    menudialogs_i18n[no_menudialogs_i18n].defstr = _filenames;                 \
-    menudialogs_i18n[no_menudialogs_i18n].deffloat = 0;                        \
-    menudialogs_i18n[no_menudialogs_i18n].deffloat2 = 0;                       \
     ++no_menudialogs_i18n;
 
 #define NULL_I()                                                               \

--- a/src/ui/customdialog.cpp
+++ b/src/ui/customdialog.cpp
@@ -14,8 +14,6 @@
 #include <quadmath.h>
 #endif
 
-QStringList fnames = {};
-
 QString format(number_t number)
 {
     char buf[256];
@@ -87,27 +85,6 @@ CustomDialog::CustomDialog(struct uih_context *uih, const menuitem *item,
             else
                 connect(chooser, SIGNAL(clicked()), this,
                         SLOT(chooseOutputFile()));
-
-            QBoxLayout *layout = new QBoxLayout(QBoxLayout::LeftToRight);
-            layout->setContentsMargins(0, 0, 0, 0);
-            layout->addWidget(filename);
-            layout->addWidget(chooser);
-
-            formLayout->addRow(label, layout);
-
-        } else if (dialog[i].type == DIALOG_IFILES) {
-
-            QLineEdit *filename = new QLineEdit(dialog[i].defstr, this);
-            QFontMetrics metric(filename->font());
-            filename->setMinimumWidth(metric.width(filename->text()) * 1.1);
-            filename->setObjectName(label);
-
-
-            QToolButton *chooser = new QToolButton(this);
-            chooser->setObjectName(label);
-            chooser->setText("...");
-            connect(chooser, SIGNAL(clicked()), this,
-                    SLOT(chooseInputFiles()));
 
             QBoxLayout *layout = new QBoxLayout(QBoxLayout::LeftToRight);
             layout->setContentsMargins(0, 0, 0, 0);
@@ -247,9 +224,6 @@ void CustomDialog::accept()
             QComboBox *field = findChild<QComboBox *>(label);
             m_parameters[i].dint = field->currentIndex();
 
-        }
-        else if (m_dialog[i].type == DIALOG_IFILES){
-                    m_parameters[i].dstring = (char* )malloc(sizeof(char)); // FIXME Prevents mem leak
         } else {
 
             QLineEdit *field = findChild<QLineEdit *>(label);
@@ -301,19 +275,6 @@ void CustomDialog::chooseOutputFile()
     if (!fileName.isNull()) {
         field->setText(fileName);
         settings.setValue("MainWindow/lastFileLocation", QFileInfo(fileName).absolutePath());
-    }
-}
-
-void CustomDialog::chooseInputFiles()
-{
-    QLineEdit *field = findChild<QLineEdit *>(sender()->objectName());
-    QSettings settings;
-    QString fileLocation = settings.value("MainWindow/lastFileLocation", QDir::homePath()).toString();
-    fnames = QFileDialog::getOpenFileNames(
-        this, sender()->objectName(), fileLocation, "*.xpf *.xaf");
-    if(!fnames.isEmpty()) {
-        field->setText(QString::number(fnames.size()));
-        settings.setValue("MainWindow/lastFileLocation", QFileInfo(fnames[0]).absolutePath());
     }
 }
 

--- a/src/ui/customdialog.h
+++ b/src/ui/customdialog.h
@@ -7,9 +7,6 @@
 #include <QSlider>
 
 #include "ui.h"
-
-extern QStringList fnames;
-
 class CustomDialog : public QDialog
 {
     Q_OBJECT
@@ -24,7 +21,6 @@ class CustomDialog : public QDialog
     QSlider *seedslider, *algoslider, *shiftslider;
   private slots:
     void chooseInputFile();
-    void chooseInputFiles();
     void chooseOutputFile();
     void updateVisualiser();
 


### PR DESCRIPTION
Reverts xaos-project/XaoS#184

The patch basically works well, but I found the following issues:

* It seems that displayed messages can be mixed between animations.
* The naming would be better to be related with the original filenames and not the selection number.
* If this patch works correctly, we no longer need the Render... menu. But instead of removing it, I suggest we use the Render... menu and allow selection of multiple files in that menu.