### PR TITLE
Improve Rendering

### DIFF
--- a/src/include/xmenu.h
+++ b/src/include/xmenu.h
@@ -1,4 +1,4 @@
-﻿#ifndef XMENU_H
+#ifndef XMENU_H
 #define XMENU_H
 #include "xio.h"
 #include "config.h"
@@ -32,6 +32,7 @@ typedef char *(*tokenfunc)(struct uih_context *c);
 #define DIALOG_ONOFF 8
 #define DIALOG_COORD 9
 #define DIALOG_PALSLIDER 10
+#define DIALOG_IFILES 11
 
 #define DIALOGIFILE(question, filename)                                        \
     {                                                                          \
@@ -72,6 +73,10 @@ typedef char *(*tokenfunc)(struct uih_context *c);
 #define DIALOGPALSLIDER(question, default)                                     \
     {                                                                          \
         question, DIALOG_SLIDER, default                                       \
+    }
+#define DIALOGIFILES(question, filenames)                                      \
+    {                                                                          \
+        question, DIALOG_IFILES, 0, filenames                                  \
     }
 
 #define DIALOGIFILE_I(_question, _filename)                                    \
@@ -151,6 +156,15 @@ typedef char *(*tokenfunc)(struct uih_context *c);
     menudialogs_i18n[no_menudialogs_i18n].type = DIALOG_IFILES;                \
     menudialogs_i18n[no_menudialogs_i18n].defint = 0;                          \
     menudialogs_i18n[no_menudialogs_i18n].defstr = _filenames;                 \
+    ++no_menudialogs_i18n;
+
+#define NULL_I()                                                               \
+    menudialogs_i18n[no_menudialogs_i18n].question = NULL;                     \
+    menudialogs_i18n[no_menudialogs_i18n].type = 0;                            \
+    menudialogs_i18n[no_menudialogs_i18n].defint = 0;                          \
+    menudialogs_i18n[no_menudialogs_i18n].defstr = NULL;                       \
+    menudialogs_i18n[no_menudialogs_i18n].deffloat = 0;                        \
+    menudialogs_i18n[no_menudialogs_i18n].deffloat2 = 0;                       \
     ++no_menudialogs_i18n;
 
 typedef struct menuitem {

--- a/src/include/xmenu.h
+++ b/src/include/xmenu.h
@@ -156,8 +156,6 @@ typedef char *(*tokenfunc)(struct uih_context *c);
     menudialogs_i18n[no_menudialogs_i18n].type = DIALOG_IFILES;                \
     menudialogs_i18n[no_menudialogs_i18n].defint = 0;                          \
     menudialogs_i18n[no_menudialogs_i18n].defstr = _filenames;                 \
-    menudialogs_i18n[no_menudialogs_i18n].deffloat = 0;                        \
-    menudialogs_i18n[no_menudialogs_i18n].deffloat2 = 0;                       \
     ++no_menudialogs_i18n;
 
 #define NULL_I()                                                               \

--- a/src/ui-hlp/menu.cpp
+++ b/src/ui-hlp/menu.cpp
@@ -1,4 +1,4 @@
-﻿#include <cerrno>
+#include <cerrno>
 #include <cstring>
 #include <cstdlib>
 #include <QMessageBox>
@@ -13,6 +13,7 @@
 #include "play.h"
 #include "i18n.h"
 #include "xthread.h"
+#include "customdialog.h"
 
 #define LANG(name, name2)                                                      \
     MENUSTRING("lang", NULL, name, name2, 0,                                   \
@@ -62,7 +63,7 @@ const char *const uih_colornames[] = {"white", "black", "red", NULL};
  * Zoltan Kovacs <kovzol@math.u-szeged.hu>, 2003-01-05
  */
 
-#define MAX_MENUDIALOGS_I18N 104
+#define MAX_MENUDIALOGS_I18N 115
 #define Register(variable) variable = &menudialogs_i18n[no_menudialogs_i18n]
 static menudialog menudialogs_i18n[MAX_MENUDIALOGS_I18N];
 // static int no_menudialogs_i18n;
@@ -1058,6 +1059,7 @@ void uih_registermenus_i18n(void)
                 MENUFLAG_INTERRUPT, uih_loadpngfile, loadimgdialog);
     MENUDIALOG_I("file", NULL, TR("Menu", "Save image"), "saveimg", 0,
                  uih_savepngfile, saveimgdialog);
+    MENUSEPARATOR_I("file");
     MENUDIALOG_I("file", NULL, TR("Menu", "Render"), "renderanim", UI,
                  uih_render, uih_renderdialog);
     MENUSEPARATOR_I("file");

--- a/src/ui-hlp/menu.cpp
+++ b/src/ui-hlp/menu.cpp
@@ -77,8 +77,7 @@ static menudialog *uih_perturbationdialog, *uih_juliadialog,
     *uih_filterdialog, *uih_shiftdialog, *uih_speeddialog, *printdialog,
     *uih_bailoutdialog, *uih_threaddialog, *saveanimdialog, *uih_juliamodedialog,
     *uih_textposdialog, *uih_fastmodedialog, *uih_timedialog, *uih_numdialog,
-    *uih_fpdialog, *palettedialog, *uih_cyclingdialog, *loadimgdialog, *palettegradientdialog,
-    *uih_batchrenderdialog
+    *uih_fpdialog, *palettedialog, *uih_cyclingdialog, *loadimgdialog, *palettegradientdialog
 #ifdef USE_SFFE
     ,
     *uih_sffedialog, *uih_sffeinitdialog
@@ -118,20 +117,7 @@ void uih_registermenudialogs_i18n(void)
     NULL_I();
 
     Register(uih_renderdialog);
-    DIALOGIFILE_I(TR("Dialog", "File to render:"), "fract*.xaf");
-    DIALOGOFILE_I(TR("Dialog", "Basename:"), "anim");
-    DIALOGINT_I(TR("Dialog", "Width:"), 640);
-    DIALOGINT_I(TR("Dialog", "Height:"), 480);
-    DIALOGFLOAT_I(TR("Dialog", "Pixel width (cm):"), 0.025);
-    DIALOGFLOAT_I(TR("Dialog", "Pixel height (cm):"), 0.025);
-    DIALOGFLOAT_I(TR("Dialog", "Framerate:"), 30);
-    DIALOGCHOICE_I(TR("Dialog", "Image type:"), imgtypes, 0);
-    DIALOGCHOICE_I(TR("Dialog", "Antialiasing:"), yesno, 0);
-    DIALOGCHOICE_I(TR("Dialog", "Always recalculate:"), yesno, 0);
-    NULL_I();
-
-    Register(uih_batchrenderdialog);
-    DIALOGIFILES_I(TR("Dialog", "Files to render:"), NULL);
+    DIALOGIFILES_I(TR("Dialog", "Files to render:"), 0);
     DIALOGOFILE_I(TR("Dialog", "Basename:"), "anim");
     DIALOGINT_I(TR("Dialog", "Width:"), 640);
     DIALOGINT_I(TR("Dialog", "Height:"), 480);
@@ -354,50 +340,8 @@ static void uih_smoothmorph(struct uih_context *c, dialogparam *p)
 
 static void uih_render(struct uih_context *c, dialogparam *d)
 {
-    if (d[2].dint <= 0 || d[2].dint > 4096) {
-        uih_error(
-            c,
-            TR("Error",
-               "renderanim: Width parameter must be positive integer in the range 0..4096"));
-        return;
-    }
-    if (d[3].dint <= 0 || d[3].dint > 4096) {
-        uih_error(
-            c,
-            TR("Error",
-               "renderanim: Height parameter must be positive integer in the range 0..4096"));
-        return;
-    }
-    if (d[4].number <= 0 || d[5].number <= 0) {
-        uih_error(c,
-                  TR("Error",
-                     "renderanim: Invalid real width and height dimensions"));
-        return;
-    }
-    if (d[6].number <= 0 || d[6].number >= 1000000) {
-        uih_error(c, TR("Error", "renderanim: invalid framerate"));
-        return;
-    }
-    if (d[7].dint && d[8].dint) {
-        uih_error(
-            c, TR("Error",
-                  "renderanim: antialiasing not supported in 256 color mode"));
-        return;
-    }
-    uih_renderanimation(c, d[1].dstring, (xio_path)d[0].dstring, d[2].dint,
-                        d[3].dint, d[4].number, d[5].number,
-                        (int)(1000000 / d[6].number),
-#ifdef STRUECOLOR24
-                        d[7].dint ? C256 : TRUECOLOR24,
-#else
-                        d[7].dint ? C256 : TRUECOLOR,
-#endif
-                        d[8].dint, d[9].dint, c->letterspersec, NULL);
-}
 
-static void uih_batchrender(struct uih_context *c, dialogparam *d)
-{
-    if(fnames.isEmpty()) {
+    if(fnames.size() == 0) {
         uih_error(c, "No file Selected");
         return;
     }
@@ -432,12 +376,14 @@ static void uih_batchrender(struct uih_context *c, dialogparam *d)
         return;
     }
     for(int i=0; i < (int)fnames.size(); i++) {
+
         QString hlpmsg = "Rendering (" + QString::number(i) + "/" +
                 QString::number(fnames.size()) + ") " + fnames[i];
         uih_message(c, hlpmsg.toStdString().c_str());
+
         char* curr_file = strdup(fnames[i].toStdString().c_str());
-                strdup(d[1].dstring);
-        QString file_number = "_" + QString::number(i) + "_";
+
+        QString file_number = "_" + fnames[i].split("/").back().split(".").front() + "_";
         char* file_suffix = strdup(file_number.toStdString().c_str());
         char* base_name = (char *)malloc(strlen(d[1].dstring) + strlen(file_suffix) + 2);
         strcpy(base_name, d[1].dstring);
@@ -455,8 +401,6 @@ static void uih_batchrender(struct uih_context *c, dialogparam *d)
         free(base_name);
     }
 }
-
-
 
 static menudialog *uih_getcolordialog(struct uih_context *c)
 {
@@ -1118,8 +1062,6 @@ void uih_registermenus_i18n(void)
     MENUSEPARATOR_I("file");
     MENUDIALOG_I("file", NULL, TR("Menu", "Render"), "renderanim", UI,
                  uih_render, uih_renderdialog);
-    MENUDIALOG_I("file", NULL, TR("Menu", "Batch Render"), "batchrender", UI,
-                 uih_batchrender, uih_batchrenderdialog);
     MENUSEPARATOR_I("file");
     MENUNOP_I("file", NULL, TR("Menu", "Load random example"), "loadexample",
               MENUFLAG_INTERRUPT, uih_loadexample);

--- a/src/ui/customdialog.cpp
+++ b/src/ui/customdialog.cpp
@@ -1,4 +1,4 @@
-﻿#include <QtWidgets>
+#include <QtWidgets>
 #define __USE_MINGW_ANSI_STDIO 1 // for long double support on Windows
 #include <cstdio>
 
@@ -13,6 +13,8 @@
 #ifdef USE_FLOAT128
 #include <quadmath.h>
 #endif
+
+QStringList fnames = {};
 
 QString format(number_t number)
 {
@@ -243,7 +245,8 @@ void CustomDialog::accept()
             QComboBox *field = findChild<QComboBox *>(label);
             m_parameters[i].dint = field->currentIndex();
 
-        } else if (m_dialog[i].type == DIALOG_IFILES){
+        }
+        else if (m_dialog[i].type == DIALOG_IFILES){
 
             QTextEdit *field = findChild<QTextEdit *>(label);
             QString raw_fnames = field->toPlainText();

--- a/src/ui/customdialog.cpp
+++ b/src/ui/customdialog.cpp
@@ -97,11 +97,9 @@ CustomDialog::CustomDialog(struct uih_context *uih, const menuitem *item,
 
         } else if (dialog[i].type == DIALOG_IFILES) {
 
-            QLineEdit *filename = new QLineEdit(dialog[i].defstr, this);
-            QFontMetrics metric(filename->font());
-            filename->setMinimumWidth(metric.width(filename->text()) * 1.1);
-            filename->setObjectName(label);
-
+            QTextEdit *filenames = new QTextEdit(this);
+            filenames->setMaximumHeight(filenames->height() * 2);
+            filenames->setObjectName(label);
 
             QToolButton *chooser = new QToolButton(this);
             chooser->setObjectName(label);
@@ -111,7 +109,7 @@ CustomDialog::CustomDialog(struct uih_context *uih, const menuitem *item,
 
             QBoxLayout *layout = new QBoxLayout(QBoxLayout::LeftToRight);
             layout->setContentsMargins(0, 0, 0, 0);
-            layout->addWidget(filename);
+            layout->addWidget(filenames);
             layout->addWidget(chooser);
 
             formLayout->addRow(label, layout);
@@ -249,7 +247,11 @@ void CustomDialog::accept()
 
         }
         else if (m_dialog[i].type == DIALOG_IFILES){
-                    m_parameters[i].dstring = (char* )malloc(sizeof(char)); // FIXME Prevents mem leak
+
+            QTextEdit *field = findChild<QTextEdit *>(label);
+            QString raw_fnames = field->toPlainText();
+            fnames = raw_fnames.split("\n");
+
         } else {
 
             QLineEdit *field = findChild<QLineEdit *>(label);
@@ -306,14 +308,16 @@ void CustomDialog::chooseOutputFile()
 
 void CustomDialog::chooseInputFiles()
 {
-    QLineEdit *field = findChild<QLineEdit *>(sender()->objectName());
+    QTextEdit *field = findChild<QTextEdit *>(sender()->objectName());
     QSettings settings;
     QString fileLocation = settings.value("MainWindow/lastFileLocation", QDir::homePath()).toString();
-    fnames = QFileDialog::getOpenFileNames(
+    QStringList fileNames = QFileDialog::getOpenFileNames(
         this, sender()->objectName(), fileLocation, "*.xpf *.xaf");
-    if(!fnames.isEmpty()) {
-        field->setText(QString::number(fnames.size()));
-        settings.setValue("MainWindow/lastFileLocation", QFileInfo(fnames[0]).absolutePath());
+    if(!fileNames.isEmpty()) {
+        for(auto file: fileNames) {
+            field->append(file);
+        }
+        settings.setValue("MainWindow/lastFileLocation", QFileInfo(fileNames[0]).absolutePath());
     }
 }
 

--- a/src/ui/customdialog.h
+++ b/src/ui/customdialog.h
@@ -1,4 +1,4 @@
-﻿#ifndef CUSTOMDIALOG_H
+#ifndef CUSTOMDIALOG_H
 #define CUSTOMDIALOG_H
 
 #include <QDialog>
@@ -7,6 +7,9 @@
 #include <QSlider>
 
 #include "ui.h"
+
+extern QStringList fnames;
+
 class CustomDialog : public QDialog
 {
     Q_OBJECT
@@ -21,6 +24,7 @@ class CustomDialog : public QDialog
     QSlider *seedslider, *algoslider, *shiftslider;
   private slots:
     void chooseInputFile();
+    void chooseInputFiles();
     void chooseOutputFile();
     void updateVisualiser();
 


### PR DESCRIPTION
After #184 , there were some changes regarding batch rendering

> The patch basically works well, but I found the following issues:
> It seems that displayed messages can be mixed between animations.
> The naming would be better to be related with the original filenames and not the selection number.
> If this patch works correctly, we no longer need the Render... menu. But instead of removing it, I suggest we use the Render... menu and allow selection of multiple files in that menu.

These are addressed in this PR