### PR TITLE
Remove extra options from Render Image Menu

### DIFF
--- a/src/ui-hlp/menu.cpp
+++ b/src/ui-hlp/menu.cpp
@@ -136,10 +136,8 @@ void uih_registermenudialogs_i18n(void)
     DIALOGINT_I(TR("Dialog", "Height:"), 480);
     DIALOGFLOAT_I(TR("Dialog", "Pixel width (cm):"), 0.025);
     DIALOGFLOAT_I(TR("Dialog", "Pixel height (cm):"), 0.025);
-    DIALOGFLOAT_I(TR("Dialog", "Framerate:"), 30);
     DIALOGCHOICE_I(TR("Dialog", "Image type:"), imgtypes, 0);
     DIALOGCHOICE_I(TR("Dialog", "Antialiasing:"), yesno, 0);
-    DIALOGCHOICE_I(TR("Dialog", "Always recalculate:"), yesno, 0);
     NULL_I();
 
     Register(uih_viewdialog);
@@ -446,11 +444,7 @@ static void uih_renderimg(struct uih_context *c, dialogparam *d)
                      "renderanim: Invalid real width and height dimensions"));
         return;
     }
-    if (d[5].number <= 0 || d[5].number >= 1000000) {
-        uih_error(c, TR("Error", "renderanim: invalid framerate"));
-        return;
-    }
-    if (d[6].dint && d[7].dint) {
+    if (d[5].dint && d[6].dint) {
         uih_error(
             c, TR("Error",
                   "renderanim: antialiasing not supported in 256 color mode"));
@@ -459,13 +453,13 @@ static void uih_renderimg(struct uih_context *c, dialogparam *d)
 
     uih_renderanimation(c, d[0].dstring, (xio_path)path, d[1].dint,
                             d[2].dint, d[3].number, d[4].number,
-                            (int)(1000000 / d[5].number),
+                            (int)(1000000 / 30),
     #ifdef STRUECOLOR24
-                            d[6].dint ? C256 : TRUECOLOR24,
+                            d[5].dint ? C256 : TRUECOLOR24,
     #else
-                            d[6].dint ? C256 : TRUECOLOR,
+                            d[5].dint ? C256 : TRUECOLOR,
     #endif
-                            d[7].dint, d[8].dint, c->letterspersec, NULL);
+                            d[6].dint, 0, c->letterspersec, NULL);
 
     remove(".xaos_temp.xpf");
 }

--- a/src/ui-hlp/menu.cpp
+++ b/src/ui-hlp/menu.cpp
@@ -417,14 +417,14 @@ static void uih_render(struct uih_context *c, dialogparam *d)
 
 static void uih_renderimg(struct uih_context *c, dialogparam *d)
 {
-    xio_file f = xio_wopen("raw_render.xpf");
+    xio_file f = xio_wopen(".xaos_temp.xpf");
     if(!f) {
-        uih_error(c, "Can't Render Image");
+        uih_error(c, "Could not Render Image");
         return;
     }
 
     uih_save_position(c, f, 0);
-    xio_constpath path = "raw_render.xpf";
+    xio_constpath path = ".xaos_temp.xpf";
 
     if (d[1].dint <= 0 || d[1].dint > 4096) {
         uih_error(
@@ -466,6 +466,8 @@ static void uih_renderimg(struct uih_context *c, dialogparam *d)
                             d[6].dint ? C256 : TRUECOLOR,
     #endif
                             d[7].dint, d[8].dint, c->letterspersec, NULL);
+
+    remove(".xaos_temp.xpf");
 }
 
 static menudialog *uih_getcolordialog(struct uih_context *c)


### PR DESCRIPTION
Framerate and always recalculate options are now removed from render image menu.