### PR TITLE
Unify open/ open image and save/ save image

### DIFF
--- a/src/ui-hlp/menu.cpp
+++ b/src/ui-hlp/menu.cpp
@@ -77,7 +77,7 @@ static menudialog *uih_perturbationdialog, *uih_juliadialog,
     *uih_filterdialog, *uih_shiftdialog, *uih_speeddialog, *printdialog,
     *uih_bailoutdialog, *uih_threaddialog, *saveanimdialog, *uih_juliamodedialog,
     *uih_textposdialog, *uih_fastmodedialog, *uih_timedialog, *uih_numdialog,
-    *uih_fpdialog, *palettedialog, *uih_cyclingdialog, *loadimgdialog, *palettegradientdialog,
+    *uih_fpdialog, *palettedialog, *uih_cyclingdialog, *palettegradientdialog,
     *uih_renderimgdialog
 #ifdef USE_SFFE
     ,
@@ -177,15 +177,11 @@ void uih_registermenudialogs_i18n(void)
     NULL_I();
 
     Register(loaddialog);
-    DIALOGIFILE_I(TR("Dialog", "Filename:"), "fract*.xpf");
+    DIALOGIFILE_I(TR("Dialog", "Filename:"), "*.png *.xpf");
     NULL_I();
 
     Register(playdialog);
     DIALOGIFILE_I(TR("Dialog", "Filename:"), "anim*.xaf");
-    NULL_I();
-
-    Register(loadimgdialog);
-    DIALOGIFILE_I(TR("Dialog", "Filename:"), "fract*.png");
     NULL_I();
 
     Register(saveimgdialog);
@@ -1110,17 +1106,15 @@ void uih_registermenus_i18n(void)
                  loaddialog);
     MENUDIALOG_I("file", NULL, TR("Menu", "Save"), "savepos", 0,
                  uih_saveposfile, saveposdialog);
+    SUBMENU_I("file", NULL, TR("Menu", "Save as"), "saveas");
+    MENUDIALOG_I("saveas", NULL, TR("Menu", "PNG"), "saveimg", 0,
+                 uih_savepngfile, saveimgdialog);
     MENUSEPARATOR_I("file")
     MENUDIALOGCB_I("file", NULL, TR("Menu", "Record"), "record", 0,
                    uih_saveanimfile, saveanimdialog, uih_saveanimenabled);
     MENUDIALOG_I("file", NULL, TR("Menu", "Replay"), "play",
                  MENUFLAG_INTERRUPT | MENUFLAG_NOPLAY, uih_playfile,
                  playdialog);
-    MENUSEPARATOR_I("file");
-    MENUDIALOG_I("file", NULL, TR("Menu", "Open image"), "loadimg",
-                MENUFLAG_INTERRUPT, uih_loadpngfile, loadimgdialog);
-    MENUDIALOG_I("file", NULL, TR("Menu", "Save image"), "saveimg", 0,
-                 uih_savepngfile, saveimgdialog);
     MENUSEPARATOR_I("file");
     MENUDIALOG_I("file", NULL, TR("Menu", "Render"), "renderanim", UI,
                  uih_render, uih_renderdialog);

--- a/src/ui-hlp/ui_helper.cpp
+++ b/src/ui-hlp/ui_helper.cpp
@@ -537,6 +537,16 @@ void uih_cycling_continue(struct uih_context *c)
 
 void uih_loadfile(struct uih_context *c, xio_constpath d)
 {
+    int los = strlen(d);
+    char ext[4];
+    if(los < 3)
+        return;
+    memcpy(ext, &d[los-3], 3);
+    if(strcmp(ext, "png") == 0) {
+        uih_loadpngfile(c, d);
+        return;
+    }
+
     xio_file f;
     f = xio_ropen(d);
     if (f == NULL) {

--- a/src/ui/customdialog.cpp
+++ b/src/ui/customdialog.cpp
@@ -286,7 +286,7 @@ void CustomDialog::chooseInputFile()
     QSettings settings;
     QString fileLocation = settings.value("MainWindow/lastFileLocation", QDir::homePath()).toString();
     QString fileName = QFileDialog::getOpenFileName(
-        this, sender()->objectName(), fileLocation, "*.xpf *.xaf");
+        this, sender()->objectName(), fileLocation, "*.xpf *.png *.xaf");
     if (!fileName.isNull()) {
         field->setText(fileName);
         settings.setValue("MainWindow/lastFileLocation", QFileInfo(fileName).absolutePath());

--- a/src/ui/image_qt.cpp
+++ b/src/ui/image_qt.cpp
@@ -70,7 +70,8 @@ const char *writepng(xio_constpath filename, const struct image *image, xio_file
         QString xpf_chunk = xio_getstring(xpf_data);
         qimage->setText("Metadata", xpf_chunk);
     }
-    qimage->save(filename);
+    if(!qimage->save(filename))
+        return "Invalid file extension";
     return NULL;
 }
 

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -826,7 +826,6 @@ void MainWindow::showDialog(const char *name)
         (dialog[0].type == DIALOG_IFILE || dialog[0].type == DIALOG_OFILE)) {
         QString filter =
             QString("*.%1").arg(QFileInfo(dialog[0].defstr).completeSuffix());
-
         QSettings settings;
         QString fileLocation =
             settings.value("MainWindow/lastFileLocation", QDir::homePath())
@@ -848,8 +847,11 @@ void MainWindow::showDialog(const char *name)
 
         if (!fileName.isNull()) {
             QString ext = "." + QFileInfo(dialog[0].defstr).suffix();
-            if (!fileName.endsWith(ext))
+
+            if (!fileName.endsWith(".xpf") and !fileName.endsWith(".png")
+                    and !fileName.endsWith(ext))
                 fileName += ext;
+
             dialogparam *param = (dialogparam *)malloc(sizeof(dialogparam));
             param->dstring = strdup(fileName.toUtf8());
             menuActivate(item, param);


### PR DESCRIPTION
Issue #190 

This PR unifies Open and Open Image menu options. Now ```Open``` is able to load png and xpf both.
Save Image has been shifted to ```Save as``` and  ```Save``` remains as it is.

![Screenshot from 2020-07-21 13-14-40](https://user-images.githubusercontent.com/5468342/88027040-5e6b4080-cb54-11ea-8239-c556187cd3f8.png)
```Save as``` should get populated in future when xaos starts supporting more export formats.

Ps. Should we rename Save as to Export as ?