### PR TITLE
Add Custom Palette aka Palette Picker

### DIFF
--- a/src/include/filter.h
+++ b/src/include/filter.h
@@ -297,6 +297,8 @@ void convertupgeneric(struct filter *f, int *x, int *y);
 void convertdowngeneric(struct filter *f, int *x, int *y);
 int fixedalloccolor(struct palette *palette, int init, int r, int g, int b);
 void getPaletteColor(struct palette *palette, int seed, int algorithm, int shift, int newColors[101][3]);
+void getDEFSEGMENTColor(unsigned char newColors[][3]);
+int mkcustompalette(struct palette *c, unsigned char newColors[27][3]);
 
 #define setfractalpalette(f, p)                                                \
     if ((f)->fractalc->palette == (f)->image->palette)                         \

--- a/src/include/xmenu.h
+++ b/src/include/xmenu.h
@@ -32,7 +32,8 @@ typedef char *(*tokenfunc)(struct uih_context *c);
 #define DIALOG_ONOFF 8
 #define DIALOG_COORD 9
 #define DIALOG_PALSLIDER 10
-#define DIALOG_IFILES 11
+#define DIALOG_PALPICKER 11
+#define DIALOG_IFILES 12
 
 #define DIALOGIFILE(question, filename)                                        \
     {                                                                          \
@@ -148,6 +149,12 @@ typedef char *(*tokenfunc)(struct uih_context *c);
 #define DIALOGPALSLIDER_I(_question, _default)                                 \
     menudialogs_i18n[no_menudialogs_i18n].question = _question;                \
     menudialogs_i18n[no_menudialogs_i18n].type = DIALOG_PALSLIDER;             \
+    menudialogs_i18n[no_menudialogs_i18n].defint = _default;                   \
+    ++no_menudialogs_i18n;
+
+#define DIALOGPALPICKER_I(_question, _default)                                 \
+    menudialogs_i18n[no_menudialogs_i18n].question = _question;                \
+    menudialogs_i18n[no_menudialogs_i18n].type = DIALOG_PALPICKER;             \
     menudialogs_i18n[no_menudialogs_i18n].defint = _default;                   \
     ++no_menudialogs_i18n;
 

--- a/src/ui-hlp/menu.cpp
+++ b/src/ui-hlp/menu.cpp
@@ -78,7 +78,7 @@ static menudialog *uih_perturbationdialog, *uih_juliadialog,
     *uih_bailoutdialog, *uih_threaddialog, *saveanimdialog, *uih_juliamodedialog,
     *uih_textposdialog, *uih_fastmodedialog, *uih_timedialog, *uih_numdialog,
     *uih_fpdialog, *palettedialog, *uih_cyclingdialog, *palettegradientdialog,
-    *uih_renderimgdialog
+    *uih_renderimgdialog, *palettepickerdialog
 #ifdef USE_SFFE
     ,
     *uih_sffedialog, *uih_sffeinitdialog
@@ -281,6 +281,10 @@ void uih_registermenudialogs_i18n(void)
 
     Register(palettegradientdialog);
     DIALOGPALSLIDER_I("Visualiser:", 0);
+    NULL_I();
+
+    Register(palettepickerdialog);
+    DIALOGPALPICKER_I("Palette:", 0);
     NULL_I();
 
     Register(uih_cyclingdialog);
@@ -653,6 +657,11 @@ static menudialog *uih_getpalettegradientdialog(struct uih_context *uih)
     return (palettegradientdialog);
 }
 
+static menudialog *uih_palettepickerdialog(struct uih_context /* *uih */)
+{
+    return (palettepickerdialog);
+}
+
 static menudialog *uih_getcyclingdialog(struct uih_context *uih)
 {
     if (uih != NULL)
@@ -707,7 +716,6 @@ static void uih_palette(struct uih_context *uih, dialogparam *p)
 
 static void uih_palettegradient(struct uih_context *uih, dialogparam *p)
 {
-    fflush(stdout);
     int n1 = uih->palettetype;
     int n2 = uih->paletteseed;
     int shift = uih->paletteshift;
@@ -732,6 +740,11 @@ static void uih_palettegradient(struct uih_context *uih, dialogparam *p)
         uih_newimage(uih);
     }
     uih->paletteshift = shift;
+}
+
+static void uih_palettepicker(struct uih_context *uih, dialogparam *p)
+{
+    uih_newimage(uih);
 }
 
 static int uih_rotateselected(struct uih_context *c, int n)
@@ -1195,6 +1208,8 @@ void uih_registermenus_i18n(void)
                   0, uih_palette, uih_getpalettedialog); //This is a placeholder menu
     MENUCDIALOG_I("palettemenu", NULL, TR("Menu", "Custom palette"), "palettegradient",
                   0, uih_palettegradient, uih_getpalettegradientdialog);
+    MENUCDIALOG_I("palettemenu", NULL, TR("Menu", "Palette Picker"), "palettepicker",
+                  0, uih_palettepicker, uih_palettepickerdialog);
     MENUSEPARATOR_I("palettemenu");
     MENUNOPCB_I("palettemenu", "y", TR("Menu", "Color cycling"), "cycling", 0,
                 uih_cyclingsw, uih_cyclingselected);

--- a/src/ui/customdialog.cpp
+++ b/src/ui/customdialog.cpp
@@ -189,6 +189,39 @@ CustomDialog::CustomDialog(struct uih_context *uih, const menuitem *item,
             connect(shiftno,SIGNAL(valueChanged(int)), shiftslider, SLOT(setValue(int)));
             connect(shiftslider, SIGNAL(valueChanged(int)), shiftno, SLOT(setValue(int)));
             connect(shiftno, SIGNAL(valueChanged(int)), this, SLOT(updateVisualiser()));
+
+        } else if(dialog[i].type == DIALOG_PALPICKER) {
+
+            palcontext = uih;
+            getDEFSEGMENTColor(newColors);
+
+            QList< QPushButton* > buttons;
+            QBoxLayout *layout1 = new QBoxLayout(QBoxLayout::LeftToRight);
+            QBoxLayout *layout2 = new QBoxLayout(QBoxLayout::LeftToRight);
+            QBoxLayout *layout3 = new QBoxLayout(QBoxLayout::LeftToRight);
+            for(auto bidx = 0; bidx < 31; ++bidx ) {
+                auto button = new QPushButton{ QString::number(bidx) };
+                button->setObjectName(QString::number(bidx));
+                QColor color(newColors[bidx][0], newColors[bidx][1], newColors[bidx][2]);
+                QPalette pal = button->palette();
+                button->setAutoFillBackground(true);
+                pal.setColor(QPalette::Button, color);
+                button->setPalette(pal);
+                button->update();
+                buttons << button;
+                if(bidx <= 10)
+                    layout1->addWidget(button);
+                else if(bidx>10 and bidx <= 20)
+                    layout2->addWidget(button);
+                else
+                    layout3->addWidget(button);
+
+                connect(button, SIGNAL(clicked()), this, SLOT(colorPicker()));
+            }
+            formLayout->addRow("Outer", layout1);
+            formLayout->addRow("Mid", layout2);
+            formLayout->addRow("Inner", layout3);
+
         } else {
 
             QLineEdit *field = new QLineEdit(this);
@@ -268,6 +301,8 @@ void CustomDialog::accept()
                 palcontext->paletteshift = shiftno->value();
                 m_parameters[i].dint = 1;
                 destroypalette(gradientpal);
+            } else if (m_dialog[i].type == DIALOG_PALPICKER) {
+                mkcustompalette(palcontext->image->palette, newColors);
             }
             else
                 m_parameters[i].dstring = strdup(field->text().toUtf8());
@@ -340,4 +375,19 @@ void CustomDialog::updateVisualiser()
     // Save Result
     QPixmap newImage = QPixmap::fromImage(palImage.scaled(this->algono->width(), this->algono->height()));
     img->setPixmap(newImage);
+}
+
+void CustomDialog::colorPicker()
+{
+    QPushButton* button = qobject_cast<QPushButton*>(sender());
+    int idx = button->objectName().toInt();
+    QColor color = QColorDialog::getColor(Qt::yellow, this );
+    QPalette pal = button->palette();
+    button->setAutoFillBackground(true);
+    pal.setColor(QPalette::Button, color);
+    button->setPalette(pal);
+    button->update();
+    newColors[idx][0] = color.red();
+    newColors[idx][1] = color.green();
+    newColors[idx][2] = color.blue();
 }

--- a/src/ui/customdialog.h
+++ b/src/ui/customdialog.h
@@ -5,6 +5,7 @@
 #include <QLabel>
 #include <QSpinBox>
 #include <QSlider>
+#include <QMouseEvent>
 
 #include "ui.h"
 
@@ -22,11 +23,13 @@ class CustomDialog : public QDialog
     QSpinBox *algono, *seedno, *shiftno;
     QLabel *img;
     QSlider *seedslider, *algoslider, *shiftslider;
+    unsigned char newColors[][3];
   private slots:
     void chooseInputFile();
     void chooseInputFiles();
     void chooseOutputFile();
     void updateVisualiser();
+    void colorPicker();
 
   public:
     CustomDialog(struct uih_context *uih, const menuitem *item,

--- a/src/ui/customdialog.h
+++ b/src/ui/customdialog.h
@@ -5,7 +5,6 @@
 #include <QLabel>
 #include <QSpinBox>
 #include <QSlider>
-#include <QMouseEvent>
 
 #include "ui.h"
 

--- a/src/util/palette.cpp
+++ b/src/util/palette.cpp
@@ -1100,3 +1100,37 @@ void getPaletteColor(struct palette *src, int seed, int algorithm, int shift, in
         newColors[i][2]=b;
     }
 }
+
+void getDEFSEGMENTColor(unsigned char newColors[][3]) {
+    memcpy(newColors, colors, sizeof(colors1));
+}
+
+int mkcustompalette(struct palette *c, unsigned char newColors[31][3])
+{
+    int i, ncolors = c->size;
+    context = c;
+    needupdate = 0;
+    segmentsize = 8;
+
+    if (c->flags & DONOTCHANGE)
+        return 0;
+    memcpy(colors, newColors, sizeof(colors1));
+    maxentries = context->maxentries - nprecells;
+    if (c->flags & UNKNOWNENTRIES)
+        i = 128 / 8;
+    else
+        i = (maxentries + 3) / 8;
+    if (i < 0)
+        i = 1;
+    mksmooth(255 / 8, i);
+    if (!(c->flags & FINISHLATER)) {
+        if (c->allocfinished != NULL)
+            c->allocfinished(c);
+    } else
+        c->flags |= UNFINISHED;
+    if (context->size != ncolors || needupdate) {
+        context->version++;
+        return 1;
+    }
+    return 0;
+}

--- a/src/util/xmenu.cpp
+++ b/src/util/xmenu.cpp
@@ -358,6 +358,7 @@ void menu_activate(const menuitem *item, struct uih_context *c, dialogparam *d)
                     switch (di[0].type) {
                         case DIALOG_INT:
                         case DIALOG_PALSLIDER:
+                        case DIALOG_PALPICKER:
                         case DIALOG_CHOICE:
                         case DIALOG_ONOFF:
                             ((void (*)(struct uih_context * c, int))


### PR DESCRIPTION
Fixes #15 #165 
Type: Enhancement

What was added?
Option to choose custom color palette from 31 base colors ranging from outside most to inside.

Where to find?
Fractal -> Palette -> Palette Picker

Screenshots -:

![Screenshot from 2020-07-28 00-41-12](https://user-images.githubusercontent.com/5468342/88581694-2cce0a00-d06b-11ea-9627-b1ca2b85de5b.png)
![Screenshot from 2020-07-28 00-41-27](https://user-images.githubusercontent.com/5468342/88581690-2c357380-d06b-11ea-873a-0ae41bf03b99.png)
![Screenshot from 2020-07-28 00-41-41](https://user-images.githubusercontent.com/5468342/88581686-2b044680-d06b-11ea-9e72-436b5b3e1a22.png)

Future Scope:
User should be able to load/ download the color profile in a extension such as ```.gpl``` for easily sharing it across system or reusing it.