### PR TITLE
Add ability to save/load palette

### DIFF
--- a/src/ui/customdialog.cpp
+++ b/src/ui/customdialog.cpp
@@ -320,8 +320,15 @@ void CustomDialog::chooseInputFile()
 
     QSettings settings;
     QString fileLocation = settings.value("MainWindow/lastFileLocation", QDir::homePath()).toString();
-    QString fileName = QFileDialog::getOpenFileName(
-        this, sender()->objectName(), fileLocation, "*.xpf *.png *.xaf");
+    QString fileName;
+
+    if(sender()->objectName() == "Load Palette File:") {
+        fileName = QFileDialog::getOpenFileName(
+            this, sender()->objectName(), fileLocation, "*.gpl");
+    } else {
+        fileName = QFileDialog::getOpenFileName(
+            this, sender()->objectName(), fileLocation, "*.xpf *.png *.xaf");
+    }
     if (!fileName.isNull()) {
         field->setText(fileName);
         settings.setValue("MainWindow/lastFileLocation", QFileInfo(fileName).absolutePath());


### PR DESCRIPTION
Fixes #193 
Type: Enhancement

What's new?
Easy loading and sharing of palette as a ```.gpl``` extension file.
Press ```x``` to launch palette picker

![Screenshot from 2020-08-11 03-26-17](https://user-images.githubusercontent.com/5468342/89835555-a04f3b80-db82-11ea-803a-91a3a4e2f3d6.png)


