### PR TITLE
Improve load/ save palette config

### DIFF
--- a/src/ui-hlp/menu.cpp
+++ b/src/ui-hlp/menu.cpp
@@ -1,6 +1,7 @@
 #include <cerrno>
 #include <cstring>
 #include <cstdlib>
+#include <iomanip>
 #include <QFile>
 #include <QTextStream>
 #include <QMessageBox>
@@ -815,7 +816,9 @@ static void uih_savegpl(struct uih_context *uih, xio_constpath d) {
             stream << "Name: XaoS_Palette" << "\n";
             stream << "Columns: 16" << "\n" << "#" << "\n";
             for(int i=0; i < 31; i++){
-                stream << (int)colors[i][0] << " " << (int)colors[i][1] << " " << (int)colors[i][2] << "\n";
+                char s[256];
+                sprintf(s, "%3d %3d %3d", colors[i][0], colors[i][1], colors[i][2]);
+                stream << s << "\t color_" << QString::number(i) << "\n";
             }
             savefile->close();
             char s[256];

--- a/src/ui-hlp/menu.cpp
+++ b/src/ui-hlp/menu.cpp
@@ -766,19 +766,14 @@ static void uih_loadgpl(struct uih_context *uih, xio_constpath d)
     if (loadfile->open(QIODevice::ReadOnly | QIODevice::Text)) {
         QTextStream in(loadfile);
         QStringList colorvals= in.readAll().split("\n");
-        if((int)colorvals.size() != 33) {
+        if((int)colorvals.size() != 36) {
             uih_error(uih, "Corrupted palette File");
             loadfile->close();
             return;
         }
 
-        for(int i=1; i < 32; i++) {
+        for(int i = 4; i < 35; i++) {
             QStringList currcolors = colorvals[i].split(QRegExp("\\s+"));
-            if(currcolors.size() != 3) {
-                uih_error(uih, "Corrupted Color File");
-                loadfile->close();
-                return;
-            }
             int r = currcolors[0].toInt();
             int g = currcolors[1].toInt();
             int b = currcolors[2].toInt();
@@ -791,9 +786,9 @@ static void uih_loadgpl(struct uih_context *uih, xio_constpath d)
                 return;
             }
 
-            colors[i-1][0] = r;
-            colors[i-1][1] = g;
-            colors[i-1][2] = b;
+            colors[i-4][0] = r;
+            colors[i-4][1] = g;
+            colors[i-4][2] = b;
         }
         mkcustompalette(uih->palette, colors);
         loadfile->close();
@@ -817,6 +812,8 @@ static void uih_savegpl(struct uih_context *uih, xio_constpath d) {
             getDEFSEGMENTColor(colors);
             QTextStream stream(savefile);
             stream << "GIMP Palette" << "\n";
+            stream << "Name: XaoS_Palette" << "\n";
+            stream << "Columns: 16" << "\n" << "#" << "\n";
             for(int i=0; i < 31; i++){
                 stream << (int)colors[i][0] << " " << (int)colors[i][1] << " " << (int)colors[i][2] << "\n";
             }

--- a/src/ui/customdialog.cpp
+++ b/src/ui/customdialog.cpp
@@ -320,15 +320,8 @@ void CustomDialog::chooseInputFile()
 
     QSettings settings;
     QString fileLocation = settings.value("MainWindow/lastFileLocation", QDir::homePath()).toString();
-    QString fileName;
-
-    if(sender()->objectName() == "Load Palette File:") {
-        fileName = QFileDialog::getOpenFileName(
-            this, sender()->objectName(), fileLocation, "*.gpl");
-    } else {
-        fileName = QFileDialog::getOpenFileName(
+    QString fileName = QFileDialog::getOpenFileName(
             this, sender()->objectName(), fileLocation, "*.xpf *.png *.xaf");
-    }
     if (!fileName.isNull()) {
         field->setText(fileName);
         settings.setValue("MainWindow/lastFileLocation", QFileInfo(fileName).absolutePath());


### PR DESCRIPTION
From #194 loading and saving of palette was introduced.

- Users can now open the palette config file ```.gpl``` with GIMP/ or can manually edit it.
- Options are now moved to Fractal -> Palette -> as ```Load Palette Config``` and ```Save Palette Config```

![Screenshot from 2020-08-12 00-08-49](https://user-images.githubusercontent.com/5468342/89935696-35f4d480-dc30-11ea-9cd1-92c5f7a9b54f.png)