### PR TITLE
Save palette colors to XPF and PNG

### DIFF
--- a/src/include/filter.h
+++ b/src/include/filter.h
@@ -299,6 +299,8 @@ int fixedalloccolor(struct palette *palette, int init, int r, int g, int b);
 void getPaletteColor(struct palette *palette, int seed, int algorithm, int shift, int newColors[101][3]);
 void getDEFSEGMENTColor(unsigned char newColors[][3]);
 int mkcustompalette(struct palette *c, unsigned char newColors[27][3]);
+void rgbtohex (int r, int g, int b, char color[6]);
+void hextorgb (char *hexcolor, rgb_t color);
 
 #define setfractalpalette(f, p)                                                \
     if ((f)->fractalc->palette == (f)->image->palette)                         \

--- a/src/include/ui_helper.h
+++ b/src/include/ui_helper.h
@@ -183,6 +183,7 @@ struct uih_context {
     int viewchanged;    /*When to generate setview commands */
     int palettechanged; /*When to generate setpalette commands */
     int displaytext;    /*When text was displayed in this frame */
+    int palettepickerenabled; /*If palette picker is used */
     int nonfractalscreen;
     /*waiting variables */
     void (*complettehandler)(

--- a/src/ui-hlp/menu.cpp
+++ b/src/ui-hlp/menu.cpp
@@ -764,6 +764,7 @@ static void uih_palettegradient(struct uih_context *uih, dialogparam *p)
 
 static void uih_palettecolors(struct uih_context *uih, dialogparam *p){
     unsigned char colors[31][3];
+    memset(colors, 0, sizeof (colors));
     for(int i=0; i < 31; i++) {
         rgb_t color;
         hextorgb(p[i].dstring, color);
@@ -771,10 +772,7 @@ static void uih_palettecolors(struct uih_context *uih, dialogparam *p){
         colors[i][1] = color[1];
         colors[i][2] = color[2];
     }
-    int c = mkcustompalette(uih->palette, colors);
-    if (c) {
-        uih_message(uih, "Failed to apply palette");
-    }
+    mkcustompalette(uih->palette, colors);
     uih_newimage(uih);
     uih->palettepickerenabled = 1;
 }
@@ -818,10 +816,7 @@ static void uih_loadgpl(struct uih_context *uih, xio_constpath d)
             colors[i-4][1] = g;
             colors[i-4][2] = b;
         }
-        int c = mkcustompalette(uih->palette, colors);
-        if (c) {
-            uih_message(uih, "Failed to apply palette");
-        }
+        mkcustompalette(uih->palette, colors);
         loadfile->close();
         char s[256];
         sprintf(s, TR("Message", "File %s opened."), d);

--- a/src/ui-hlp/save.cpp
+++ b/src/ui-hlp/save.cpp
@@ -336,6 +336,18 @@ void uih_saveframe(struct uih_context *uih)
             uih->palettechanged = 0;
             s->manualpaletteshift = 0;
         }
+        if (uih->palettepickerenabled) {
+            start_save(uih, "palettecolors");
+            unsigned char colors[31][3];
+            getDEFSEGMENTColor(colors);
+            for (int i=0; i<31; i++) {
+                char currcolor[6];
+                rgbtohex(colors[i][0], colors[i][1],
+                         colors[i][2], currcolor);
+                save_string(uih, currcolor);
+            }
+            stop_save(uih);
+        }
         if (s->manualpaletteshift != uih->manualpaletteshift)
             save_intc(uih, "shiftpalette",
                       uih->manualpaletteshift - s->manualpaletteshift),

--- a/src/ui/image_qt.cpp
+++ b/src/ui/image_qt.cpp
@@ -1,10 +1,26 @@
 ﻿#include <QtWidgets>
-
 #include "config.h"
 #include "filter.h"
 #include "grlib.h"
 #include "xio.h"
 #include "misc-f.h"
+
+void rgbtohex (int r, int g, int b, char color[6]) {
+    QColor rgb(r, g, b);
+    QString hex = rgb.name();
+    hex.remove(0, 1);
+    strcpy(color, hex.toStdString().c_str());
+}
+
+void hextorgb (char *hexcolor, rgb_t color) {
+    QString hexa = hexcolor;
+    hexa.push_front('#');
+    QColor hex(hexa);
+    QColor rgb = hex.toRgb();
+    color[0] = rgb.red();
+    color[1] = rgb.green();
+    color[2] = rgb.blue();
+}
 
 static QFont getFont(void *font) {
     if (font)


### PR DESCRIPTION
Type: Enhancement
Fixes #196 

XPF file and PNG now contains palette colors. The colors are to be passed in hex format.
Sample xpf file:
```
;Position file automatically generated by XaoS 4.1
;  - a realtime interactive fractal zoomer
;Use xaos -loadpos <filename> to display it
(initstate)
(defaultpalette 0)
(palettecolors "ffffff" "fce94f" "180719" "c5421c" "1d120b" "872e47" "181b0d" "f1e680" "111f18" "f0a28b" "0b041e" "6a57bd" "1d150e" "0c8c76" "0a061d" "32904d" "160018" "94bcf3" "042007" "e7920e" "0a0d14" "b89344" "0d1c03" "a9f898" "040022" "3e5330" "071516" "9861b8" "08030c" "f75ceb" "1f2010")
(formula 'mandel)
(view -0.75 0 2.5 2.5)
```
Using Command Line:
```
xaos -palettecolors  "ffffff" "fce94f" "180719" "c5421c" "1d120b" "872e47" "181b0d" "f1e680" "111f18" "f0a28b" "0b041e" "6a57bd" "1d150e" "0c8c76" "0a061d" "32904d" "160018" "94bcf3" "042007" "e7920e" "0a0d14" "b89344" "0d1c03" "a9f898" "040022" "3e5330" "071516" "9861b8" "08030c" "f75ceb" "1f2010"
```
