### PR TITLE
fix: add missing header

### DIFF
--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -23,6 +23,7 @@
 #include <cctype>
 #include <cerrno>
 #include <climits>
+#include <clocale>
 #include <cmath>
 #include <csignal>
 #include <cstdlib>


### PR DESCRIPTION
Needed on some systems because of the `setlocale(LC_NUMERIC, "C");` line.