### PR TITLE
Fixed invalid AppStream XML

### DIFF
--- a/xdg/xaos.appdata.xml
+++ b/xdg/xaos.appdata.xml
@@ -70,6 +70,7 @@
         <p>New outcoloring mode smoothlog by iaoesch.</p>
       </description>
       <url>https://github.com/xaos-project/XaoS/releases/tag/release-4.3.2</url>
+    </release>
     <release version="4.3.2" date="2024-01-07">
       <description>
         <p>Turkish translation, contributed by Selen Galiç, Zuhal Ünan, Veysel Yıldız and Emine Nur Ünveren Bilgiç.</p>


### PR DESCRIPTION
> Error: Error on line 119 char 14: Element “releases” was closed, but the currently open element is “release”