### PR TITLE
Adding alphabetical order requirement in README for new languages

### DIFF
--- a/i18n/README.md
+++ b/i18n/README.md
@@ -49,19 +49,19 @@ by defining the new language with a line
 ```
 
 where LL is the two letter ISO 639-1 code for the new language and the numbers XX
-are consecutive in the list. You probably need to renumber the list or a part of it.
+are consecutive in the list. Add new language definition in alphabetical order. You probably need to renumber the list or a part of it.
 
 5. In src/ui/main.cpp increase the number of internationalized menu items at line
 
 ```
-#define MAX_MENUITEMS_I18N 30
+#define MAX_MENUITEMS_I18N 37
 ```
 
-If you compile XaoS in debug mode, you can find the required minimal number here
+Increase it by one for each additional language. If you compile XaoS in debug mode, you can find the required minimal number here
 by checking the message "Filled ... ui menu items out of ...".
 
 6. Also, add the LL code in src/ui/main.cpp to the list languages1 and an appropriate
-[ICU](http://userguide.icu-project.org/locale) code to languages2.
+[ICU](http://userguide.icu-project.org/locale) code to languages2. Here also add a language code in alhpabetical order.
 
 7. Finally, extend the file src/ui/main.cpp with a menu entry like
 
@@ -70,9 +70,9 @@ MENUINTRB_I("setlang", NULL, "Swedish", "sv", UI, uih_setlanguage, UIH_LANG_SV, 
 ```
 
 Here the English name "Swedish" and the two letter code "sv" must be changed, and also
-UIH_LANG_SV to UIH_LANG_LL, accordingly (as defined in step 4).
+UIH_LANG_SV to UIH_LANG_LL, accordingly (as defined in step 4). The menu entry for the new language must also be inserted in alphabetical order.
 
-**Important: The languages must follow the same order in steps 4, 6 and 7.**
+**Important: The languages must follow the same alphabetical order in steps 4, 6 and 7.**
 
 ## Testing your changes
 


### PR DESCRIPTION
Adding alphabetical order requirement in i18n/README.md for new languages.