### PR TITLE
feat: implement CommunityClient C++ networking layer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,9 +128,9 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 
 if(MOBILE_UI)
-   # Mobile UI: QWidget + QML overlay
-   find_package(QT NAMES Qt6 COMPONENTS Widgets Quick QuickControls2 QuickWidgets Qml REQUIRED)
-   find_package(Qt6 COMPONENTS Widgets Quick QuickControls2 QuickWidgets Qml REQUIRED)
+   # Mobile UI: QWidget + QML overlay + Network for community sharing
+   find_package(QT NAMES Qt6 COMPONENTS Widgets Quick QuickControls2 QuickWidgets Qml Network REQUIRED)
+   find_package(Qt6 COMPONENTS Widgets Quick QuickControls2 QuickWidgets Qml Network REQUIRED)
 else()
    # Desktop UI: Qt Widgets based
    find_package(QT NAMES Qt6 COMPONENTS Widgets PrintSupport REQUIRED)
@@ -198,11 +198,11 @@ file(GLOB C_FILES src/sffe/*.c)
 
 if(MOBILE_UI)
    # Mobile UI: QWidget rendering + QML overlay for touch controls
-   # Explicitly list sources — exclude old fractalquickitem/enginebridge
    set(UI_FILES
        src/ui-mobile/main_mobile.cpp
        src/ui-mobile/mobilemainwindow.cpp
        src/ui-mobile/mobilebridge.cpp
+       src/ui-mobile/communityclient.cpp
        src/ui/fractalwidget.cpp
        src/ui/image_qt.cpp
    )
@@ -236,7 +236,7 @@ elseif(MOBILE_UI)
        src/ui-mobile/ui-mobile.qrc
        ${TRANSLATIONS_QRC}
     )
-    target_link_libraries(XaoSMobile PRIVATE Qt6::Widgets Qt6::Quick Qt6::QuickControls2 Qt6::QuickWidgets Qt6::Qml)
+    target_link_libraries(XaoSMobile PRIVATE Qt6::Widgets Qt6::Quick Qt6::QuickControls2 Qt6::QuickWidgets Qt6::Qml Qt6::Network)
     # Android-specific properties
     if(ANDROID)
         set_target_properties(XaoSMobile PROPERTIES

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -5,18 +5,23 @@
     android:versionCode="1"
     android:versionName="4.3">
 
+    <!-- 1. ADDED: Required permission to allow network/URL calls -->
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <supports-screens
         android:anyDensity="true"
         android:largeScreens="true"
         android:normalScreens="true"
         android:smallScreens="true" />
 
+    <!-- 2. FIXED: Repaired the broken application tag syntax -->
     <application
         android:hardwareAccelerated="true"
         android:label="XaoS Fractal Explorer"
         android:requestLegacyExternalStorage="true"
         android:allowBackup="true"
-        android:fullBackupOnly="false">
+        android:fullBackupOnly="false"
+        android:usesCleartextTraffic="true"> <!-- Clean, un-broken attributes -->
 
         <activity
             android:name="org.qtproject.qt.android.bindings.QtActivity"

--- a/src/ui-mobile/communityclient.cpp
+++ b/src/ui-mobile/communityclient.cpp
@@ -1,0 +1,673 @@
+#include "communityclient.h"
+
+#include <QFile>
+#include <QHttpMultiPart>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QSettings>
+#include <QUdpSocket>
+#include <QTimer>
+#include <QUrlQuery>
+#include "server_config.h"
+
+static const int DISCOVERY_PORT = 3001;
+static const char *EMULATOR_FALLBACK_URL = COMMUNITY_SERVER_URL;
+
+CommunityClient::CommunityClient(QObject *parent)
+    : QObject(parent), m_nam(new QNetworkAccessManager(this)) {
+  QSettings settings("XaoS", "CommunityClient");
+  m_sessionToken = settings.value("sessionToken").toString();
+  m_userRole = settings.value("userRole").toString();
+  m_displayName = settings.value("displayName").toString();
+  if (!m_sessionToken.isEmpty()) {
+      QTimer::singleShot(500, this, [this]() {
+          emit authChanged();
+          fetchUserRooms();
+      });
+  }
+  startDiscovery();
+}
+
+
+void CommunityClient::startDiscovery() {
+  m_discoverySocket = new QUdpSocket(this);
+  if (m_discoverySocket->bind(QHostAddress::AnyIPv4, DISCOVERY_PORT,
+                               QUdpSocket::ShareAddress |
+                                   QUdpSocket::ReuseAddressHint)) {
+    connect(m_discoverySocket, &QUdpSocket::readyRead, this,
+            &CommunityClient::onDiscoveryDatagram);
+    qDebug() << "CommunityClient: Listening for server beacon on UDP port"
+             << DISCOVERY_PORT;
+  } else {
+    qWarning() << "CommunityClient: Failed to bind discovery socket on port"
+               << DISCOVERY_PORT << m_discoverySocket->errorString();
+  }
+
+  if (!m_serverFound) {
+      m_serverUrl = QString(EMULATOR_FALLBACK_URL);
+      m_serverFound = true;
+      emit serverUrlChanged();
+      emit serverDiscovered();
+      qDebug() << "CommunityClient: Initialized with emulator fallback at"
+               << m_serverUrl;
+  }
+}
+
+void CommunityClient::onDiscoveryDatagram() {
+  while (m_discoverySocket->hasPendingDatagrams()) {
+    QByteArray data;
+    data.resize(m_discoverySocket->pendingDatagramSize());
+    QHostAddress sender;
+    quint16 senderPort;
+    m_discoverySocket->readDatagram(data.data(), data.size(), &sender,
+                                    &senderPort);
+
+    QJsonDocument doc = QJsonDocument::fromJson(data);
+    if (!doc.isObject())
+      continue;
+
+    QJsonObject obj = doc.object();
+    if (obj["service"].toString() != "xaos-community")
+      continue;
+
+    QString ip = obj["ip"].toString();
+    int port = obj["port"].toInt();
+    if (ip.isEmpty() || port == 0)
+      continue;
+
+    QString url = QStringLiteral("http://%1:%2").arg(ip).arg(port);
+
+    if (m_serverUrl != url || !m_serverFound) {
+      m_serverUrl = url;
+      m_serverFound = true;
+      emit serverUrlChanged();
+      emit serverDiscovered();
+      qDebug() << "CommunityClient: Server discovered at" << url;
+    }
+  }
+}
+
+
+void CommunityClient::setServerUrl(const QString &url) {
+  if (m_serverUrl != url) {
+    m_serverUrl = url;
+    emit serverUrlChanged();
+  }
+}
+
+void CommunityClient::setLoading(bool loading) {
+  if (m_loading != loading) {
+    m_loading = loading;
+    emit loadingChanged();
+  }
+}
+
+void CommunityClient::setError(const QString &error) {
+  m_error = error;
+  emit errorChanged();
+  if (!error.isEmpty()) {
+    emit networkError(error);
+  }
+}
+
+
+void CommunityClient::fetchRoomMembers(int roomId) {
+  if (m_serverUrl.isEmpty() || m_sessionToken.isEmpty())
+    return;
+
+  QUrl url(m_serverUrl + QStringLiteral("/api/rooms/%1/members").arg(roomId));
+  QNetworkRequest request(url);
+  request.setRawHeader("Authorization", ("Bearer " + m_sessionToken).toUtf8());
+
+  QNetworkReply *reply = m_nam->get(request);
+  connect(reply, &QNetworkReply::finished, this,
+          [this, reply]() { onRoomMembersFinished(reply); });
+}
+
+void CommunityClient::upload(const QString &title, const QString &author,
+                             const QString &xpfData,
+                             const QString &thumbnailPath,
+                             const QString &formula, int iterations,
+                             const QString &zoomLevel,
+                             int targetGroupId) {
+  if (m_loading)
+    return;
+
+  if (m_serverUrl.isEmpty()) {
+    setError("Server not found yet. Waiting for discovery...");
+    return;
+  }
+
+  setLoading(true);
+  setError("");
+
+  QUrl url(m_serverUrl + "/api/fractals");
+  QNetworkRequest request(url);
+  if (!m_sessionToken.isEmpty()) {
+    request.setRawHeader("Authorization",
+                         ("Bearer " + m_sessionToken).toUtf8());
+  }
+
+  auto *multiPart = new QHttpMultiPart(QHttpMultiPart::FormDataType);
+
+  QHttpPart titlePart;
+  titlePart.setHeader(QNetworkRequest::ContentDispositionHeader,
+                      QVariant("form-data; name=\"title\""));
+  titlePart.setBody(title.toUtf8());
+  multiPart->append(titlePart);
+
+  QHttpPart authorPart;
+  authorPart.setHeader(QNetworkRequest::ContentDispositionHeader,
+                       QVariant("form-data; name=\"author\""));
+  authorPart.setBody(
+      (author.isEmpty() ? QStringLiteral("Anonymous") : author).toUtf8());
+  multiPart->append(authorPart);
+
+  QHttpPart xpfPart;
+  xpfPart.setHeader(QNetworkRequest::ContentDispositionHeader,
+                     QVariant("form-data; name=\"xpf\""));
+  xpfPart.setBody(xpfData.toUtf8());
+  multiPart->append(xpfPart);
+
+  if (!formula.isEmpty()) {
+    QHttpPart formulaPart;
+    formulaPart.setHeader(QNetworkRequest::ContentDispositionHeader,
+                          QVariant("form-data; name=\"formula\""));
+    formulaPart.setBody(formula.toUtf8());
+    multiPart->append(formulaPart);
+  }
+
+  QHttpPart iterPart;
+  iterPart.setHeader(QNetworkRequest::ContentDispositionHeader,
+                     QVariant("form-data; name=\"iterations\""));
+  iterPart.setBody(QByteArray::number(iterations));
+  multiPart->append(iterPart);
+
+  int uploadGroupId = (targetGroupId == -2) ? m_groupId : targetGroupId;
+  if (uploadGroupId > 0) {
+    QHttpPart groupPart;
+    groupPart.setHeader(QNetworkRequest::ContentDispositionHeader,
+                        QVariant("form-data; name=\"groupId\""));
+    groupPart.setBody(QByteArray::number(uploadGroupId));
+    multiPart->append(groupPart);
+  }
+
+  if (!zoomLevel.isEmpty()) {
+    QHttpPart zoomPart;
+    zoomPart.setHeader(QNetworkRequest::ContentDispositionHeader,
+                       QVariant("form-data; name=\"zoomLevel\""));
+    zoomPart.setBody(zoomLevel.toUtf8());
+    multiPart->append(zoomPart);
+  }
+
+  if (!thumbnailPath.isEmpty()) {
+    QFile *thumbFile = new QFile(thumbnailPath);
+    if (thumbFile->open(QIODevice::ReadOnly)) {
+      QHttpPart thumbPart;
+      thumbPart.setHeader(
+          QNetworkRequest::ContentDispositionHeader,
+          QVariant(
+              "form-data; name=\"thumbnail\"; filename=\"thumbnail.png\""));
+      thumbPart.setHeader(QNetworkRequest::ContentTypeHeader,
+                          QVariant("image/png"));
+      thumbPart.setBodyDevice(thumbFile);
+      thumbFile->setParent(multiPart);
+      multiPart->append(thumbPart);
+    } else {
+      delete thumbFile;
+    }
+  }
+
+  QNetworkReply *reply = m_nam->post(request, multiPart);
+  multiPart->setParent(reply);
+
+  connect(reply, &QNetworkReply::finished, this,
+          [this, reply]() { onUploadFinished(reply); });
+}
+
+void CommunityClient::onUploadFinished(QNetworkReply *reply) {
+  reply->deleteLater();
+  setLoading(false);
+
+  if (reply->error() != QNetworkReply::NoError) {
+    setError(QStringLiteral("Upload failed: ") + reply->errorString());
+    return;
+  }
+
+  QByteArray data = reply->readAll();
+  QJsonDocument doc = QJsonDocument::fromJson(data);
+  if (!doc.isObject()) {
+    setError("Invalid server response");
+    return;
+  }
+
+  QJsonObject obj = doc.object();
+  if (obj.contains("error")) {
+    setError(obj["error"].toString());
+    return;
+  }
+
+  int id = obj["id"].toInt();
+  emit uploadComplete(id);
+}
+
+
+void CommunityClient::fetchGallery(int page, const QString &sort) {
+  if (m_loading)
+    return;
+
+  if (m_serverUrl.isEmpty()) {
+    setError("Server not found yet. Waiting for discovery...");
+    return;
+  }
+
+  setLoading(true);
+  setError("");
+
+  QUrl url(m_serverUrl + "/api/fractals");
+  QUrlQuery query;
+  query.addQueryItem("page", QString::number(page));
+  query.addQueryItem("sort", sort);
+  query.addQueryItem("limit", "20");
+  if (m_groupId > 0) {
+    query.addQueryItem("groupId", QString::number(m_groupId));
+  }
+  url.setQuery(query);
+
+  QNetworkRequest request(url);
+  if (!m_sessionToken.isEmpty()) {
+    request.setRawHeader("Authorization",
+                         ("Bearer " + m_sessionToken).toUtf8());
+  }
+  QNetworkReply *reply = m_nam->get(request);
+
+  connect(reply, &QNetworkReply::finished, this,
+          [this, reply]() { onGalleryFinished(reply); });
+}
+
+void CommunityClient::onGalleryFinished(QNetworkReply *reply) {
+  reply->deleteLater();
+  setLoading(false);
+
+  if (reply->error() != QNetworkReply::NoError) {
+    setError(QStringLiteral("Gallery load failed: ") + reply->errorString());
+    return;
+  }
+
+  QByteArray data = reply->readAll();
+  QJsonDocument doc = QJsonDocument::fromJson(data);
+  if (!doc.isObject()) {
+    setError("Invalid server response");
+    return;
+  }
+
+  QJsonObject obj = doc.object();
+  int totalPages = obj["totalPages"].toInt();
+  int currentPage = obj["page"].toInt();
+
+  QJsonArray arr = obj["items"].toArray();
+  QVariantList items;
+  items.reserve(arr.size());
+
+  for (const QJsonValue &val : arr) {
+    QJsonObject item = val.toObject();
+    QVariantMap map;
+    map["id"] = item["id"].toInt();
+    map["title"] = item["title"].toString();
+    map["author"] = item["author"].toString();
+    map["formula"] = item["formula"].toString();
+    map["iterations"] = item["iterations"].toInt();
+    map["zoomLevel"] = item["zoom_level"].toString();
+    map["downloads"] = item["downloads"].toInt();
+    map["likes"] = item["likes"].toInt();
+    map["createdAt"] = item["created_at"].toString();
+
+    if (!item["thumbnailUrl"].isNull()) {
+      map["thumbnailUrl"] = m_serverUrl + item["thumbnailUrl"].toString();
+    } else {
+      map["thumbnailUrl"] = QString();
+    }
+
+    items.append(map);
+  }
+
+  emit galleryLoaded(items, totalPages, currentPage);
+}
+
+
+void CommunityClient::downloadXpf(int fractalId) {
+  if (m_loading)
+    return;
+
+  if (m_serverUrl.isEmpty()) {
+    setError("Server not found yet. Waiting for discovery...");
+    return;
+  }
+
+  setLoading(true);
+  setError("");
+
+  QUrl url(m_serverUrl +
+           QStringLiteral("/api/fractals/%1/xpf").arg(fractalId));
+  QNetworkRequest request(url);
+  QNetworkReply *reply = m_nam->get(request);
+
+  connect(reply, &QNetworkReply::finished, this,
+          [this, reply, fractalId]() { onXpfFinished(reply, fractalId); });
+}
+
+void CommunityClient::onXpfFinished(QNetworkReply *reply, int fractalId) {
+  reply->deleteLater();
+  setLoading(false);
+
+  if (reply->error() != QNetworkReply::NoError) {
+    setError(QStringLiteral("Download failed: ") + reply->errorString());
+    return;
+  }
+
+  QString xpfData = QString::fromUtf8(reply->readAll());
+  emit xpfDownloaded(fractalId, xpfData);
+}
+
+
+void CommunityClient::teacherLogin(const QString &email,
+                                    const QString &password) {
+  if (m_loading)
+    return;
+
+  if (m_serverUrl.isEmpty()) {
+    setError("Server not found yet. Waiting for discovery...");
+    return;
+  }
+
+  setLoading(true);
+  setError("");
+
+  QUrl url(m_serverUrl + "/api/auth/teacher/login");
+  QNetworkRequest request(url);
+  request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
+
+  QJsonObject obj;
+  obj["email"] = email;
+  obj["password"] = password;
+
+  QNetworkReply *reply = m_nam->post(request, QJsonDocument(obj).toJson());
+  connect(reply, &QNetworkReply::finished, this,
+          [this, reply]() { onAuthFinished(reply); });
+}
+
+void CommunityClient::teacherSignup(const QString &email, const QString &password, const QString &displayName) {
+  if (m_loading)
+    return;
+
+  if (m_serverUrl.isEmpty()) {
+    setError("Server not found yet. Waiting for discovery...");
+    return;
+  }
+
+  setLoading(true);
+  setError("");
+
+  QUrl url(m_serverUrl + "/api/auth/teacher/signup");
+  QNetworkRequest request(url);
+  request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
+
+  QJsonObject obj;
+  obj["email"] = email;
+  obj["password"] = password;
+  obj["displayName"] = displayName;
+
+  QNetworkReply *reply = m_nam->post(request, QJsonDocument(obj).toJson());
+  connect(reply, &QNetworkReply::finished, this,
+          [this, reply]() { onAuthFinished(reply); });
+}
+
+void CommunityClient::joinGroup(const QString &inviteCode,
+                                 const QString &displayName) {
+  if (m_loading)
+    return;
+
+  if (m_serverUrl.isEmpty()) {
+    setError("Server not found yet. Waiting for discovery...");
+    return;
+  }
+
+  setLoading(true);
+  setError("");
+
+  QUrl url(m_serverUrl + "/api/auth/student/join");
+  QNetworkRequest request(url);
+  request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
+
+  if (!m_sessionToken.isEmpty()) {
+    request.setRawHeader("Authorization", ("Bearer " + m_sessionToken).toUtf8());
+  }
+
+  QJsonObject obj;
+  obj["inviteCode"] = inviteCode;
+  obj["displayName"] = displayName;
+
+  QNetworkReply *reply = m_nam->post(request, QJsonDocument(obj).toJson());
+  connect(reply, &QNetworkReply::finished, this,
+          [this, reply]() { onAuthFinished(reply); });
+}
+
+void CommunityClient::createRoom(const QString &roomName) {
+  if (m_loading) return;
+  if (m_serverUrl.isEmpty() || m_sessionToken.isEmpty()) return;
+
+  setLoading(true);
+  setError("");
+
+  QUrl url(m_serverUrl + "/api/groups");
+  QNetworkRequest request(url);
+  request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
+  request.setRawHeader("Authorization", ("Bearer " + m_sessionToken).toUtf8());
+
+  QJsonObject obj;
+  obj["name"] = roomName;
+
+  QNetworkReply *reply = m_nam->post(request, QJsonDocument(obj).toJson());
+  connect(reply, &QNetworkReply::finished, this,
+          [this, reply]() { onRoomCreated(reply); });
+}
+
+void CommunityClient::logout() {
+  m_sessionToken.clear();
+  m_userRole.clear();
+  m_displayName.clear();
+  m_groupId = -1;
+  m_groupName.clear();
+  m_userRooms.clear();
+
+  QSettings settings("XaoS", "CommunityClient");
+  settings.remove("sessionToken");
+  settings.remove("userRole");
+  settings.remove("displayName");
+
+  emit authChanged();
+  emit userRoomsChanged();
+}
+
+void CommunityClient::fetchUserRooms() {
+  if (m_serverUrl.isEmpty() || m_sessionToken.isEmpty())
+    return;
+
+  QUrl url(m_serverUrl + "/api/user/rooms");
+  QNetworkRequest request(url);
+  request.setRawHeader("Authorization", ("Bearer " + m_sessionToken).toUtf8());
+  QNetworkReply *reply = m_nam->get(request);
+  connect(reply, &QNetworkReply::finished, this,
+          [this, reply]() { onRoomsFinished(reply); });
+}
+
+void CommunityClient::leaveRoom(int roomId) {
+  if (m_serverUrl.isEmpty() || m_sessionToken.isEmpty())
+    return;
+
+  QUrl url(m_serverUrl + QStringLiteral("/api/rooms/%1/leave").arg(roomId));
+  QNetworkRequest request(url);
+  request.setRawHeader("Authorization", ("Bearer " + m_sessionToken).toUtf8());
+  QNetworkReply *reply = m_nam->post(request, QByteArray());
+  connect(reply, &QNetworkReply::finished, this,
+          [this, reply]() { onLeaveFinished(reply); });
+}
+
+void CommunityClient::selectRoom(int roomId, const QString &roomName) {
+  if (m_groupId == roomId && m_groupName == roomName) return;
+  m_groupId = roomId;
+  m_groupName = roomName;
+  emit authChanged();
+}
+
+void CommunityClient::likeFractal(int fractalId) {
+  if (m_serverUrl.isEmpty())
+    return;
+
+  QUrl url(m_serverUrl +
+           QStringLiteral("/api/fractals/%1/like").arg(fractalId));
+  QNetworkRequest request(url);
+  if (!m_sessionToken.isEmpty()) {
+    request.setRawHeader("Authorization",
+                         ("Bearer " + m_sessionToken).toUtf8());
+  }
+  QNetworkReply *reply = m_nam->post(request, QByteArray());
+  connect(reply, &QNetworkReply::finished, reply, &QObject::deleteLater);
+}
+
+void CommunityClient::onAuthFinished(QNetworkReply *reply) {
+  reply->deleteLater();
+  setLoading(false);
+
+  QByteArray data = reply->readAll();
+  QJsonDocument doc = QJsonDocument::fromJson(data);
+
+  if (reply->error() != QNetworkReply::NoError) {
+    if (doc.isObject() && doc.object().contains("error")) {
+      setError(doc.object()["error"].toString());
+    } else {
+      setError(QStringLiteral("Auth failed: ") + reply->errorString());
+    }
+    return;
+  }
+
+  if (!doc.isObject()) {
+    setError("Invalid server response");
+    return;
+  }
+
+  QJsonObject obj = doc.object();
+  if (obj.contains("error")) {
+    setError(obj["error"].toString());
+    return;
+  }
+
+  m_sessionToken = obj["token"].toString();
+  QJsonObject userObj = obj["user"].toObject();
+  m_userRole = userObj["role"].toString();
+  m_displayName = userObj["displayName"].toString();
+
+  if (obj.contains("group")) {
+    QJsonObject groupObj = obj["group"].toObject();
+    m_groupId = groupObj["id"].toInt();
+    m_groupName = groupObj["name"].toString();
+  }
+
+  QSettings settings("XaoS", "CommunityClient");
+  settings.setValue("sessionToken", m_sessionToken);
+  settings.setValue("userRole", m_userRole);
+  settings.setValue("displayName", m_displayName);
+
+  emit authChanged();
+  emit loginSuccess();
+  fetchUserRooms();
+}
+
+void CommunityClient::onRoomsFinished(QNetworkReply *reply) {
+  reply->deleteLater();
+  if (reply->error() != QNetworkReply::NoError) return;
+  
+  QByteArray data = reply->readAll();
+  QJsonDocument doc = QJsonDocument::fromJson(data);
+  if (!doc.isObject()) return;
+  
+  QJsonArray arr = doc.object()["rooms"].toArray();
+  QVariantList rooms;
+  for (const QJsonValue &val : arr) {
+    QJsonObject item = val.toObject();
+    QVariantMap map;
+    map["id"] = item["id"].toInt();
+    map["name"] = item["name"].toString();
+    map["inviteCode"] = item["invite_code"].toString();
+    map["createdBy"] = item["created_by"].toInt();
+    rooms.append(map);
+  }
+  
+  m_userRooms = rooms;
+  emit userRoomsChanged();
+}
+
+void CommunityClient::onRoomCreated(QNetworkReply *reply) {
+  setLoading(false);
+  reply->deleteLater();
+
+  if (reply->error() != QNetworkReply::NoError) {
+    QByteArray errData = reply->readAll();
+    QJsonDocument doc = QJsonDocument::fromJson(errData);
+    if (doc.isObject() && doc.object().contains("error")) {
+      setError(doc.object()["error"].toString());
+    } else {
+      setError("Failed to create room");
+    }
+    return;
+  }
+
+  QByteArray data = reply->readAll();
+  QJsonDocument doc = QJsonDocument::fromJson(data);
+  if (doc.isObject() && doc.object().contains("id")) {
+    int id = doc.object()["id"].toInt();
+    QString name = doc.object()["name"].toString();
+    QString inviteCode = doc.object()["inviteCode"].toString();
+
+    fetchUserRooms();
+    selectRoom(id, name);
+    emit roomCreated(id, name, inviteCode);
+  }
+}
+
+void CommunityClient::onRoomMembersFinished(QNetworkReply *reply) {
+  reply->deleteLater();
+  if (reply->error() != QNetworkReply::NoError) return;
+  
+  QByteArray data = reply->readAll();
+  QJsonDocument doc = QJsonDocument::fromJson(data);
+  if (!doc.isObject()) return;
+  
+  QJsonArray arr = doc.object()["members"].toArray();
+  QVariantList members;
+  for (const QJsonValue &val : arr) {
+    QJsonObject item = val.toObject();
+    QVariantMap map;
+    map["id"] = item["id"].toInt();
+    map["displayName"] = item["display_name"].toString();
+    map["role"] = item["role"].toString();
+    map["joinedAt"] = item["joined_at"].toString();
+    members.append(map);
+  }
+  
+  emit roomMembersLoaded(members);
+}
+
+void CommunityClient::onLeaveFinished(QNetworkReply *reply) {
+  reply->deleteLater();
+  if (reply->error() == QNetworkReply::NoError) {
+    m_groupId = -1;
+    m_groupName = "";
+    emit authChanged();
+    fetchUserRooms();
+  }
+}

--- a/src/ui-mobile/communityclient.h
+++ b/src/ui-mobile/communityclient.h
@@ -1,0 +1,139 @@
+#ifndef COMMUNITYCLIENT_H
+#define COMMUNITYCLIENT_H
+
+#include <QObject>
+#include <QString>
+#include <QVariantList>
+
+class QNetworkAccessManager;
+class QNetworkReply;
+class QUdpSocket;
+
+/**
+ * @brief HTTP client for the XaoS Community Sharing Server.
+ *
+ * Provides methods to upload, browse, and download fractal positions
+ * via the community REST API. All network operations are asynchronous;
+ * results are delivered via signals.
+ *
+ * On construction, automatically listens for the server's UDP discovery
+ * beacon on port 3001 to find the server without hardcoded IPs.
+ *
+ * Exposed to QML as a context property ("community").
+ */
+class CommunityClient : public QObject {
+  Q_OBJECT
+
+  Q_PROPERTY(bool loading READ isLoading NOTIFY loadingChanged)
+  Q_PROPERTY(QString errorMessage READ errorMessage NOTIFY errorChanged)
+  Q_PROPERTY(QString serverUrl READ serverUrl WRITE setServerUrl NOTIFY serverUrlChanged)
+  Q_PROPERTY(bool isLoggedIn READ isLoggedIn NOTIFY authChanged)
+  Q_PROPERTY(QString currentUserRole READ currentUserRole NOTIFY authChanged)
+  Q_PROPERTY(int currentGroupId READ currentGroupId NOTIFY authChanged)
+  Q_PROPERTY(QString currentGroupName READ currentGroupName NOTIFY authChanged)
+  Q_PROPERTY(bool serverDiscovered READ isServerDiscovered NOTIFY serverDiscovered)
+  Q_PROPERTY(QString currentDisplayName READ currentDisplayName NOTIFY authChanged)
+  Q_PROPERTY(QVariantList userRooms READ userRooms NOTIFY userRoomsChanged)
+
+public:
+  explicit CommunityClient(QObject *parent = nullptr);
+
+  bool isLoading() const { return m_loading; }
+  QString errorMessage() const { return m_error; }
+  QString serverUrl() const { return m_serverUrl; }
+  void setServerUrl(const QString &url);
+
+  bool isLoggedIn() const { return !m_sessionToken.isEmpty(); }
+  QString currentUserRole() const { return m_userRole; }
+  int currentGroupId() const { return m_groupId; }
+  QString currentGroupName() const { return m_groupName; }
+  bool isServerDiscovered() const { return m_serverFound; }
+  QString currentDisplayName() const { return m_displayName; }
+  QVariantList userRooms() const { return m_userRooms; }
+
+public slots:
+  Q_INVOKABLE void clearError() { setError(""); }
+
+  Q_INVOKABLE void fetchRoomMembers(int roomId);
+
+  /**
+   * Upload a fractal to the community server.
+   */
+  Q_INVOKABLE void upload(const QString &title, const QString &author,
+                           const QString &xpfData,
+                           const QString &thumbnailPath,
+                           const QString &formula, int iterations,
+                           const QString &zoomLevel,
+                           int targetGroupId = -2);
+
+  /**
+   * Fetch a page of community fractals.
+   */
+  Q_INVOKABLE void fetchGallery(int page = 1, const QString &sort = "recent");
+
+  Q_INVOKABLE void teacherLogin(const QString &email, const QString &password);
+  Q_INVOKABLE void teacherSignup(const QString &email, const QString &password, const QString &displayName);
+  Q_INVOKABLE void joinGroup(const QString &inviteCode, const QString &displayName);
+  Q_INVOKABLE void likeFractal(int fractalId);
+  Q_INVOKABLE void logout();
+  Q_INVOKABLE void fetchUserRooms();
+  Q_INVOKABLE void leaveRoom(int roomId);
+  Q_INVOKABLE void selectRoom(int roomId, const QString &roomName);
+  Q_INVOKABLE void createRoom(const QString &roomName);
+
+  /**
+   * Download the .xpf data for a specific fractal.
+   */
+  Q_INVOKABLE void downloadXpf(int fractalId);
+
+signals:
+  void loadingChanged();
+  void errorChanged();
+  void serverUrlChanged();
+  void authChanged();
+  void loginSuccess();
+  void serverDiscovered();
+  void userRoomsChanged();
+  void roomCreated(int id, const QString &name, const QString &inviteCode);
+  void roomMembersLoaded(QVariantList members);
+
+  void uploadComplete(int id);
+
+  void galleryLoaded(const QVariantList &items, int totalPages, int currentPage);
+
+  void xpfDownloaded(int fractalId, const QString &xpfData);
+
+  void networkError(const QString &message);
+
+private slots:
+  void onUploadFinished(QNetworkReply *reply);
+  void onGalleryFinished(QNetworkReply *reply);
+  void onXpfFinished(QNetworkReply *reply, int fractalId);
+  void onAuthFinished(QNetworkReply *reply);
+  void onRoomsFinished(QNetworkReply *reply);
+  void onLeaveFinished(QNetworkReply *reply);
+  void onRoomCreated(QNetworkReply *reply);
+  void onRoomMembersFinished(QNetworkReply *reply);
+  void onDiscoveryDatagram();
+
+private:
+  void setLoading(bool loading);
+  void setError(const QString &error);
+  void startDiscovery();
+
+  QNetworkAccessManager *m_nam;
+  QUdpSocket *m_discoverySocket = nullptr;
+  bool m_loading = false;
+  bool m_serverFound = false;
+  QString m_error;
+  QString m_serverUrl;
+
+  QString m_sessionToken;
+  QString m_userRole;
+  QString m_displayName;
+  int m_groupId = -1;
+  QString m_groupName;
+  QVariantList m_userRooms;
+};
+
+#endif

--- a/src/ui-mobile/main_mobile.cpp
+++ b/src/ui-mobile/main_mobile.cpp
@@ -11,7 +11,6 @@
 
 #include "mobilemainwindow.h"
 
-// Engine headers
 #include "config.h"
 #include "filter.h"
 #include "fractal.h"
@@ -21,7 +20,6 @@
 #include "xmenu.h"
 #include "xthread.h"
 
-// Required global variables
 int printspeed = 0;
 int delaytime = 0;
 int maxframerate = 80;
@@ -35,7 +33,6 @@ extern int defthreads;
 xio_pathdata configfile;
 QStringList fnames = {};
 
-// Minimal stubs required by the engine
 int nparams = 0;
 void params_register(const struct params * /*par*/) {}
 
@@ -55,31 +52,29 @@ void uih_setlanguage(uih_context *, int) {}
 void ui_fractalinfo(struct uih_context *) {}
 void ui_registermenus_i18n(void) {}
 
+extern void uih_registermenudialogs_i18n(void);
+extern void uih_registermenus_i18n(void);
 extern void uih_registermenus(void);
 
 int main(int argc, char *argv[]) {
-  // QApplication — required for QWidget support
   QApplication app(argc, argv);
   app.setApplicationName("XaoS");
   app.setApplicationVersion(XaoS_VERSION);
   app.setOrganizationName("GNU");
 
-  // Multi-threading: auto-detect cores, cap at 4 for mobile
   int idealThreads = QThread::idealThreadCount();
   if (idealThreads <= 0)
     idealThreads = 1;
   defthreads = qMin(idealThreads, 4);
   xth_init(defthreads);
 
-  // Register engine menus
+  uih_registermenudialogs_i18n();
+  uih_registermenus_i18n();
   uih_registermenus();
 
-  // Create the mobile window and initialize
   MobileMainWindow window;
   window.init();
 
-  // Enter the event loop — this drives the fractal rendering
-  // at maximum frame rate using QTimer(0)
   window.eventLoop();
 
   return 0;

--- a/src/ui-mobile/mobilebridge.cpp
+++ b/src/ui-mobile/mobilebridge.cpp
@@ -20,13 +20,11 @@
 MobileBridge::MobileBridge(MobileMainWindow *window, QObject *parent)
     : QObject(parent), m_window(window) {}
 void MobileBridge::setUih(struct uih_context *uih) { m_uih = uih; }
-// State refresh — called from event loop to push to QML
 void MobileBridge::refreshState() {
     if (!m_uih || !m_uih->fcontext)
         return;
     bool changed = false;
     const fractal_context *fc = m_uih->fcontext;
-    // Formula name
     QString newName;
     if (fc->currentformula)
         newName = fc->currentformula->name[!fc->mandelbrot];
@@ -34,19 +32,16 @@ void MobileBridge::refreshState() {
         m_formulaName = newName;
         changed = true;
     }
-    // Max iterations
     int newIter = (int)fc->maxiter;
     if (newIter != m_maxIter) {
         m_maxIter = newIter;
         changed = true;
     }
-    // Autopilot
     bool newAP = m_uih->autopilot != 0;
     if (newAP != m_autopilot) {
         m_autopilot = newAP;
         changed = true;
     }
-    // Palette state
     int newAlg = m_uih->palettetype;
     int newSeed = m_uih->paletteseed;
     int newShift = m_uih->paletteshift + m_uih->manualpaletteshift;
@@ -56,7 +51,6 @@ void MobileBridge::refreshState() {
         m_palShift = newShift;
         changed = true;
     }
-    // Zoom magnification
     double newZoom = 1.0;
     if (fc->currentformula && fc->s.rr > 0) {
         newZoom = (double)fc->currentformula->v.rr / (double)fc->s.rr;
@@ -66,7 +60,6 @@ void MobileBridge::refreshState() {
         changed = true;
     }
     	
-  // User formula expression
   QString newUF;
   if (fc->userformula && fc->userformula->expression)
     newUF = QString::fromUtf8(fc->userformula->expression);
@@ -74,7 +67,6 @@ void MobileBridge::refreshState() {
     m_userFormula = newUF;
     changed = true;
   }
-  // User initial-value expression
   QString newUI;
   if (fc->userinitial && fc->userinitial->expression)
     newUI = QString::fromUtf8(fc->userinitial->expression);
@@ -118,9 +110,6 @@ QStringList MobileBridge::getPalettePreview(int algorithm, int seed, int shift) 
     return result;
 }
 
-// ─────────────────────────────────────────────────────────────
-// Property getters
-// ─────────────────────────────────────────────────────────────
 QString MobileBridge::formulaName() const { return m_formulaName; }
 int MobileBridge::maxIterations() const { return m_maxIter; }
 bool MobileBridge::autopilotActive() const { return m_autopilot; }
@@ -149,9 +138,6 @@ QString MobileBridge::getFormulaName(int index) const {
         return QString();
     return QString::fromUtf8(formulas[index].name[0]);
 }
-// ─────────────────────────────────────────────────────────────
-// Fractal control commands
-// ─────────────────────────────────────────────────────────────
 void MobileBridge::executeCommand(const QString &command) {
     if (!m_uih)
         return;
@@ -240,7 +226,6 @@ void MobileBridge::setCustomPalette(int algorithm, int seed, int shift) {
         return;
     uih_saveundo(m_uih);
     uih_cycling_stop(m_uih);
-    // algorithm in QML is 1-based (1..3), engine needs 0-based
     int alg0 = qBound(0, algorithm - 1, PALGORITHMS - 1);
     if (mkpalette(m_uih->zengine->fractalc->palette, seed, alg0) != 0) {
         uih_newimage(m_uih);
@@ -260,15 +245,12 @@ void MobileBridge::loadRandomExample() {
         return;
     uih_saveundo(m_uih);
     uih_cycling_stop(m_uih);
-    // 1. Pick a random formula
     int f = QRandomGenerator::global()->bounded(nformulas);
     set_formula(m_uih->fcontext, f);
-    // 2. Reset view to formula defaults
     m_uih->fcontext->s.cr = m_uih->fcontext->currentformula->v.cr;
     m_uih->fcontext->s.ci = m_uih->fcontext->currentformula->v.ci;
     m_uih->fcontext->s.rr = m_uih->fcontext->currentformula->v.rr;
     m_uih->fcontext->s.ri = m_uih->fcontext->currentformula->v.ri;
-    // 3. Pick random palette
     int seed = QRandomGenerator::global()->bounded(65536);
     int alg = QRandomGenerator::global()->bounded(PALGORITHMS);
     mkpalette(m_uih->zengine->fractalc->palette, seed, alg);
@@ -290,7 +272,6 @@ void MobileBridge::redo() {
     uih_redo(m_uih);
 }
 
-// Zoom buttons — synthetic mouse buttons
 void MobileBridge::startZoomIn() {
     m_window->setSyntheticButtons(BUTTON1);
 }
@@ -301,18 +282,15 @@ void MobileBridge::stopZoom() { m_window->setSyntheticButtons(0); }
 
 void MobileBridge::updatePointerPosition(double x, double y) {
   QPointF pos(x, y);
-  // Send the mouse position with a dummy button press so Qt doesn't drop the move event
   QMouseEvent move(QEvent::MouseMove, pos, pos, pos, Qt::MiddleButton,
                    Qt::MiddleButton, Qt::NoModifier);
   QCoreApplication::sendEvent(m_window->fractalWidget(), &move);
 }
 
-// Touch gesture translation → synthetic Qt events
 void MobileBridge::gesturePinchStarted() { m_lastPinchScale = 1.0; }
 void MobileBridge::gesturePinch(double scale, double centerX,
                                 double centerY) {
     double delta = scale / m_lastPinchScale;
-    // Threshold to avoid jitter
     if (delta > 1.02 || delta < 0.98) {
         int ticks = (delta > 1.0) ? 120 : -120;
         QPointF pos(centerX, centerY);
@@ -324,8 +302,6 @@ void MobileBridge::gesturePinch(double scale, double centerX,
 }
 void MobileBridge::gesturePan(double /*dx*/, double /*dy*/, double centerX,
                               double centerY) {
-  // If we are in Julia mode, dragging should update the Julia seed (Left Click)
-  // Otherwise, dragging pans the fractal (Middle Click)
   if (m_uih && m_uih->juliamode) {
       m_window->setSyntheticButtons(BUTTON1);
   } else {
@@ -338,7 +314,6 @@ void MobileBridge::gesturePan(double /*dx*/, double /*dy*/, double centerX,
 }
 void MobileBridge::gesturePanFinished() { m_window->setSyntheticButtons(0); }
 
-// Community sharing — save / load / thumbnail
 QString MobileBridge::getCurrentXpf() {
     if (!m_uih)
         return QString();
@@ -360,13 +335,11 @@ void MobileBridge::loadFromXpf(const QString &xpfData) {
 bool MobileBridge::saveThumbnail(const QString &path) {
     if (!m_uih || !m_uih->image || !m_uih->image->data)
         return false;
-    // Get the current fractal image from the engine
     struct image *img = m_uih->image;
     QImage *qimage =
         reinterpret_cast<QImage **>(img->data)[img->currimage];
     if (!qimage || qimage->isNull())
         return false;
-    // Scale down to 512x512 thumbnail (preserving aspect ratio)
     QImage thumbnail =
         qimage->scaled(512, 512, Qt::KeepAspectRatio, Qt::SmoothTransformation);
     return thumbnail.save(path, "PNG");

--- a/src/ui-mobile/mobilebridge.h
+++ b/src/ui-mobile/mobilebridge.h
@@ -34,10 +34,8 @@ public:
 
   void setUih(struct uih_context *uih);
 
-  /// Called from the event loop to push state changes to QML.
   void refreshState();
 
-  // Property getters
   QString formulaName() const;
   int maxIterations() const;
   bool autopilotActive() const;
@@ -53,10 +51,8 @@ public:
   bool isMandelbrot() const;
 
 public slots:
-  /// Execute a named XaoS command (e.g. "initstate", "autopilot")
   Q_INVOKABLE void executeCommand(const QString &command);
 
-  /// Fractal control
   Q_INVOKABLE void setFormula(int index);
   Q_INVOKABLE QString getFormulaName(int index) const;
   Q_INVOKABLE void setIterations(int n);
@@ -71,16 +67,13 @@ public slots:
   Q_INVOKABLE void undo();
   Q_INVOKABLE void redo();
 
-    /// User formula (SFFE)
   Q_INVOKABLE void setUserFormula(const QString &expr);
   Q_INVOKABLE void setUserInitial(const QString &expr);
   
-  /// Zoom buttons — set synthetic mouse button state
   Q_INVOKABLE void startZoomIn();
   Q_INVOKABLE void startZoomOut();
   Q_INVOKABLE void stopZoom();
 
-  /// Touch gesture translation
   Q_INVOKABLE void updatePointerPosition(double x, double y);
   Q_INVOKABLE void gesturePinchStarted();
   Q_INVOKABLE void gesturePinch(double scale, double centerX, double centerY);
@@ -88,11 +81,10 @@ public slots:
                                double centerY);
   Q_INVOKABLE void gesturePanFinished();
 
-  /// Community sharing support
-  Q_INVOKABLE QString getCurrentXpf();             // serialize current position
-  Q_INVOKABLE void loadFromXpf(const QString &xpfData);  // load a position
-  Q_INVOKABLE bool saveThumbnail(const QString &path);    // save view as PNG
-  Q_INVOKABLE QString getTempPath(const QString &filename); // temp dir helper
+  Q_INVOKABLE QString getCurrentXpf();            
+  Q_INVOKABLE void loadFromXpf(const QString &xpfData); 
+  Q_INVOKABLE bool saveThumbnail(const QString &path);   
+  Q_INVOKABLE QString getTempPath(const QString &filename);
 
 signals:
   void stateChanged();
@@ -101,7 +93,6 @@ private:
   MobileMainWindow *m_window;
   struct uih_context *m_uih = nullptr;
 
-  // Cached values to avoid unnecessary signal emissions
   QString m_formulaName;
   int m_maxIter = 0;
   bool m_autopilot = false;
@@ -117,4 +108,4 @@ private:
   double m_lastPinchScale = 1.0;
 };
 
-#endif // MOBILEBRIDGE_H
+#endif

--- a/src/ui-mobile/mobilemainwindow.cpp
+++ b/src/ui-mobile/mobilemainwindow.cpp
@@ -1,7 +1,7 @@
 #include "mobilemainwindow.h"
 #include "fractalwidget.h"
 #include "mobilebridge.h"
-// #include "communityclient.h"
+#include "communityclient.h"
 
 #include <QApplication>
 #include <QCoreApplication>
@@ -28,14 +28,12 @@
 #include "xmenu.h"
 #include "xthread.h"
 
-// Externs from ui.h / other translation units
 extern float pixelwidth, pixelheight;
 extern tl_group *syncgroup;
 extern struct image *create_image_qt(int width, int height,
                                      struct palette *palette, float pixelwidth,
                                      float pixelheight);
 
-// Static engine callbacks — these route to our MobileMainWindow instance
 static int ui_passfunc(struct uih_context *uih, int display, const char *text,
                        float percent) {
     if (uih->data) {
@@ -59,19 +57,14 @@ void ui_updatemenus(struct uih_context *uih, const char *name) {
     }
 }
 
-// ─────────────────────────────────────────────────────────────
-// Construction / destruction
-// ─────────────────────────────────────────────────────────────
 
 MobileMainWindow::MobileMainWindow(QWidget *parent) : QMainWindow(parent) {
     setWindowTitle("XaoS");
     setMouseTracking(true);
 
-    // Create the fractal rendering widget as central widget
     m_widget = new FractalWidget();
     setCentralWidget(m_widget);
 
-    // Enter fullscreen for mobile
     showFullScreen();
 
     m_messageFont = QFont(QApplication::font().family(), 12);
@@ -93,9 +86,6 @@ MobileMainWindow::~MobileMainWindow() {
     }
 }
 
-// ─────────────────────────────────────────────────────────────
-// Image creation (same palette setup as desktop)
-// ─────────────────────────────────────────────────────────────
 
 struct image *MobileMainWindow::makeImage(int width, int height) {
     struct palette *palette;
@@ -120,12 +110,8 @@ struct image *MobileMainWindow::makeImage(int width, int height) {
     return image;
 }
 
-// ─────────────────────────────────────────────────────────────
-// Initialization
-// ─────────────────────────────────────────────────────────────
 
 void MobileMainWindow::init() {
-    // Compute pixel size from screen DPI
     QScreen *screen = windowHandle() ? windowHandle()->screen()
                                      : QGuiApplication::primaryScreen();
     if (screen) {
@@ -155,38 +141,31 @@ void MobileMainWindow::init() {
     m_uih->fcontext->version++;
     uih_newimage(m_uih);
 
-    // Create timers
     tl_update_time();
     m_mainTimer = tl_create_timer();
     m_loopTimer = tl_create_timer();
     tl_reset_timer(m_mainTimer);
     tl_reset_timer(m_loopTimer);
 
-    // Create the QML overlay for mobile touch controls
     createOverlay();
 }
 
-// ─────────────────────────────────────────────────────────────
-// QML overlay — transparent layer on top of FractalWidget
-// ─────────────────────────────────────────────────────────────
 
 void MobileMainWindow::createOverlay() {
     m_bridge = new MobileBridge(this, this);
     m_bridge->setUih(m_uih);
 
-    // m_community = new CommunityClient(this);
+    m_community = new CommunityClient(this);
 
     m_overlay = new QQuickWidget(this);
     m_overlay->setResizeMode(QQuickWidget::SizeRootObjectToView);
     m_overlay->setClearColor(Qt::transparent);
     m_overlay->setAttribute(Qt::WA_AlwaysStackOnTop);
     m_overlay->setAttribute(Qt::WA_TranslucentBackground);
-    // Let touch events through transparent areas to FractalWidget
     m_overlay->setAttribute(Qt::WA_TransparentForMouseEvents, false);
 
-    // Expose bridge and community client to QML
     m_overlay->rootContext()->setContextProperty("bridge", m_bridge);
-    // m_overlay->rootContext()->setContextProperty("community", m_community);
+    m_overlay->rootContext()->setContextProperty("community", m_community);
 
     m_overlay->setSource(QUrl("qrc:/qml/main.qml"));
 
@@ -199,13 +178,9 @@ void MobileMainWindow::createOverlay() {
     m_overlay->show();
     m_overlay->raise();
 
-    // Ensure overlay covers the full window
     m_overlay->setGeometry(0, 0, width(), height());
 }
 
-// ─────────────────────────────────────────────────────────────
-// Main event loop — matches the desktop eventLoop() pattern
-// ─────────────────────────────────────────────────────────────
 
 void MobileMainWindow::eventLoop() {
     QTimer eventTimer;
@@ -217,18 +192,15 @@ void MobileMainWindow::eventLoop() {
 
         int inmovement = 1;
 
-        // Refresh QML bridge state
         if (m_bridge)
             m_bridge->refreshState();
 
-        // Render frame if engine has new data
         if (m_uih->display) {
             uih_prepare_image(m_uih);
             uih_updatestatus(m_uih);
             m_widget->repaint();
         }
 
-        // Process engine timer group
         int time = tl_process_group(syncgroup, nullptr);
         if (time != -1) {
             if (!inmovement && !m_uih->inanimation) {
@@ -242,7 +214,6 @@ void MobileMainWindow::eventLoop() {
             inmovement = 1;
         }
 
-        // Frame rate limiting
         if (delaytime || maxframerate) {
             tl_update_time();
             time = tl_lookup_timer(m_loopTimer);
@@ -256,29 +227,22 @@ void MobileMainWindow::eventLoop() {
             }
         }
 
-        // Process pending menu commands
         processQueue();
 
-        // Process input events and feed to engine
         processEvents(!inmovement && !m_uih->inanimation);
         inmovement = 0;
 
-        // Handle deferred resize
         if (m_shouldResize) {
             resizeImage(m_widget->size().width(), m_widget->size().height());
             m_shouldResize = false;
         }
     });
 
-    // Zero-interval timer — fires as fast as Qt can process events
     eventTimer.start(0);
 
     QCoreApplication::exec();
 }
 
-// ─────────────────────────────────────────────────────────────
-// Event processing (input → engine)
-// ─────────────────────────────────────────────────────────────
 
 void MobileMainWindow::processEvents(bool wait) {
     QCoreApplication::processEvents(wait ? QEventLoop::WaitForMoreEvents
@@ -291,7 +255,6 @@ void MobileMainWindow::processEvents(bool wait) {
     tl_update_time();
     uih_update(m_uih, mousex, mousey, buttons);
 
-    // Speed control via main timer
     if (tl_lookup_timer(m_mainTimer) > FRAMETIME || buttons) {
         double mul1 = tl_lookup_timer(m_mainTimer) / FRAMETIME;
         double su = 1 + (SPEEDUP - 1) * mul1;
@@ -309,7 +272,7 @@ void MobileMainWindow::processQueue() {
     dialogparam *d;
     while ((item = menu_delqueue(&d)) != NULL) {
         if (item->type == MENU_SUBMENU)
-            continue; // No submenus on mobile
+            continue;
         if (m_uih->incalculation && !(item->flags & MENUFLAG_INCALC)) {
             menu_addqueue(item, d);
             if (item->flags & MENUFLAG_INTERRUPT)
@@ -326,24 +289,18 @@ void MobileMainWindow::processQueue() {
 int MobileMainWindow::mouseButtons() {
     int buttons = 0;
 
-    // Merge synthetic buttons from QML gestures
     buttons |= m_syntheticButtons;
 
-    // Handle mouse wheel
     if (m_mouseWheel > 0)
         buttons |= BUTTON1;
     if (m_mouseWheel < 0)
         buttons |= BUTTON3;
-    // Auto-clear wheel after ~50ms
     if (m_mouseWheel != 0 && m_wheelTimer.hasExpired(50))
         m_mouseWheel = 0;
 
     return buttons;
 }
 
-// ─────────────────────────────────────────────────────────────
-// Resize
-// ─────────────────────────────────────────────────────────────
 
 void MobileMainWindow::resizeImage(int width, int height) {
     if (!m_uih)
@@ -388,7 +345,6 @@ void MobileMainWindow::resizeImage(int width, int height) {
 void MobileMainWindow::resizeEvent(QResizeEvent *event) {
     QMainWindow::resizeEvent(event);
 
-    // Keep overlay covering the full window
     if (m_overlay)
         m_overlay->setGeometry(0, 0, width(), height());
 
@@ -402,9 +358,6 @@ void MobileMainWindow::wheelEvent(QWheelEvent *event) {
 
 void MobileMainWindow::closeEvent(QCloseEvent *) { ui_quit(0); }
 
-// ─────────────────────────────────────────────────────────────
-// Engine callbacks
-// ─────────────────────────────────────────────────────────────
 
 int MobileMainWindow::showProgress(int display, const char *text,
                                    float percent) {
@@ -425,5 +378,4 @@ void MobileMainWindow::pleaseWait() {
 }
 
 void MobileMainWindow::updateMenus(const char * /*name*/) {
-    // Mobile doesn't use the traditional menu system
 }

--- a/src/ui-mobile/mobilemainwindow.h
+++ b/src/ui-mobile/mobilemainwindow.h
@@ -29,17 +29,13 @@ public:
   explicit MobileMainWindow(QWidget *parent = nullptr);
   ~MobileMainWindow();
 
-  /// Initialize the engine and start rendering.
   void init();
 
-  /// Enter the main event loop (called from main).
   void eventLoop();
 
-  /// Access for the bridge to send synthetic events
   FractalWidget *fractalWidget() const { return m_widget; }
   void setSyntheticButtons(int buttons) { m_syntheticButtons = buttons; }
 
-  // Callbacks used by the engine
   int showProgress(int display, const char *text, float percent);
   void pleaseWait();
   void updateMenus(const char *name);
@@ -57,25 +53,21 @@ private:
   void processEvents(bool wait);
   void createOverlay();
 
-  // Core state
   FractalWidget *m_widget = nullptr;
   uih_context *m_uih = nullptr;
 
-  // Timers
   tl_timer *m_mainTimer = nullptr;
   tl_timer *m_loopTimer = nullptr;
 
-  // Input state
   int m_mouseWheel = 0;
   QElapsedTimer m_wheelTimer;
   int m_syntheticButtons = 0;
   bool m_shouldResize = false;
 
-  // UI
   QFont m_messageFont;
   QQuickWidget *m_overlay = nullptr;
   MobileBridge *m_bridge = nullptr;
   CommunityClient *m_community = nullptr;
 };
 
-#endif // MOBILEMAINWINDOW_H
+#endif

--- a/src/ui-mobile/server_config.h.example
+++ b/src/ui-mobile/server_config.h.example
@@ -1,0 +1,15 @@
+#ifndef SERVER_CONFIG_H
+#define SERVER_CONFIG_H
+
+// Copy this file to server_config.h and set your server URL.
+// server_config.h is .gitignored to keep your IP private.
+//
+// For local development (Android emulator):
+//   #define COMMUNITY_SERVER_URL "http://10.0.2.2:3000"
+//
+// For production (your cloud server):
+//   #define COMMUNITY_SERVER_URL "http://YOUR_SERVER_IP:3000"
+
+#define COMMUNITY_SERVER_URL "http://10.0.2.2:3000"
+
+#endif


### PR DESCRIPTION
Adds the CommunityClient QObject wrapper to handle HTTP requests (GET/POST/Multipart) to the community server. Wires up UDP local server discovery, session token storage via QSettings, and exposes necessary signals/slots to QML. Updates Android manifest for internet permissions.